### PR TITLE
Fixes to the changed image list generation for pushes/PRs

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -24,15 +24,16 @@ jobs:
       images: ${{ steps.image-list.outputs.json }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - id: image-list
         run: |
           if [[ $GITHUB_EVENT_NAME == 'pull_request' ]] ||
              [[ $GITHUB_EVENT_NAME == 'push' ]]; then
-               # Only fetch what we need instead of a deep repo in the
-               # checkout step above to avoid in case this repo gets large
-               git fetch origin "${GITHUB_BASE_REF:=${{ github.event.before}}}" --depth=1
-               image_dirs=$(git diff --name-only origin/"$GITHUB_BASE_REF" "$GITHUB_SHA")
+               image_dirs=$(git diff --name-only \
+                                     origin/"${GITHUB_BASE_REF:-${{ github.event.before}}}" \
+                                     "$GITHUB_SHA")
           else
                image_dirs=$(find . -type d -printf "%P\n")
           fi

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -29,10 +29,26 @@ jobs:
 
       - id: image-list
         run: |
+          # Get the list of files changed based on the type of event
+          # kicking off the GHA:
+          # 1. For the main branch, diff the previous state of main vs
+          #    the current commit
+          # 2. For other branches (i.e., on someone's fork), diff main
+          #    vs the current commit
+          # 3. For PRs, diff the base ref vs the current commit
+          # 4. For everything else (e.g., dispatches), build all images
           if [[ $GITHUB_EVENT_NAME == 'pull_request' ]] ||
              [[ $GITHUB_EVENT_NAME == 'push' ]]; then
+               if [[ -n $GITHUB_BASE_REF ]]; then
+                   # GITHUB_BASE_REF is only set for PRs
+                   BASE=origin/$GITHUB_BASE_REF
+               elif [[ $GITHUB_REF == 'refs/heads/main' ]]; then
+                   BASE=${{github.event.before}}
+               else
+                   BASE=origin/main
+               fi
                image_dirs=$(git diff --name-only \
-                                     origin/"${GITHUB_BASE_REF:-${{ github.event.before}}}" \
+                                     "$BASE" \
                                      "$GITHUB_SHA")
           else
                image_dirs=$(find . -type d -printf "%P\n")

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -37,7 +37,7 @@ jobs:
                image_dirs=$(find . -type d -printf "%P\n")
           fi
 
-          images=$(echo "$images" |
+          images=$(echo "$image_dirs" |
                    fgrep opensciencegrid/ |
                    cut -d/ -f -2 |
                    sort |

--- a/opensciencegrid/frontier-squid/Dockerfile
+++ b/opensciencegrid/frontier-squid/Dockerfile
@@ -1,7 +1,8 @@
 # Specify the opensciencegrid/software-base image tag
+ARG BASE_OSG_SERIES=3.5
 ARG BASE_YUM_REPO=testing
 
-FROM opensciencegrid/software-base:3.5-el8-$BASE_YUM_REPO
+FROM opensciencegrid/software-base:$BASE_OSG_SERIES-el8-$BASE_YUM_REPO
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 

--- a/opensciencegrid/oidc-agent/Dockerfile
+++ b/opensciencegrid/oidc-agent/Dockerfile
@@ -1,6 +1,8 @@
+# Specify the opensciencegrid/software-base image tag
+ARG BASE_OSG_SERIES=3.5
 ARG BASE_YUM_REPO=release
 
-FROM opensciencegrid/software-base:3.5-el7-$BASE_YUM_REPO
+FROM opensciencegrid/software-base:$BASE_OSG_SERIES-el7-$BASE_YUM_REPO
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 

--- a/opensciencegrid/ospool-cm/Dockerfile
+++ b/opensciencegrid/ospool-cm/Dockerfile
@@ -1,5 +1,5 @@
 # Specify the opensciencegrid/software-base image tag
-ARG BASE_OSG_SERIES=3.5
+ARG BASE_OSG_SERIES=3.6
 ARG BASE_YUM_REPO=release
 
 FROM opensciencegrid/software-base:$BASE_OSG_SERIES-el7-$BASE_YUM_REPO

--- a/opensciencegrid/ospool-cm/Dockerfile
+++ b/opensciencegrid/ospool-cm/Dockerfile
@@ -1,4 +1,8 @@
-FROM opensciencegrid/software-base:3.6-el7-release
+# Specify the opensciencegrid/software-base image tag
+ARG BASE_OSG_SERIES=3.5
+ARG BASE_YUM_REPO=release
+
+FROM opensciencegrid/software-base:$BASE_OSG_SERIES-el7-$BASE_YUM_REPO
 
 RUN yum -y upgrade && \
     yum -y install \


### PR DESCRIPTION
This PR should fix the CI for pushes to personal forks (for both `main` and any other branch) and still work for PRs and pushes to `main` on this fork. Since this includes #2 , it should build all 3 images that we currently have and once that's merged, we can kick off these tests again and all the build jobs will be skipped.