### PR TITLE
Logrotate remote-messages hourly

### DIFF
--- a/opensciencegrid/central-syslog/etc/logrotate.d/remote-messages
+++ b/opensciencegrid/central-syslog/etc/logrotate.d/remote-messages
@@ -1,9 +1,10 @@
 /data/messages
 {
     missingok
-    daily
+    hourly
     compress
-    rotate 91
+    # Keep 91 days of logs
+    rotate 2184
     postrotate
         /usr/bin/supervisorctl signal HUP rsyslogd >/dev/null 2>&1 || true
     endscript


### PR DESCRIPTION
(copied from [opensciencegrid/central-syslog #2](https://github.com/opensciencegrid/central-syslog/issues/2)