### PR TITLE
Run logrotate every hour so it can rotate logs every hour

### DIFF
--- a/opensciencegrid/central-syslog/Dockerfile
+++ b/opensciencegrid/central-syslog/Dockerfile
@@ -10,4 +10,4 @@ RUN yum -y install rsyslog \
     && mkdir /data/
 
 COPY etc /etc
-
+RUN mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate


### PR DESCRIPTION
Copied from https://github.com/opensciencegrid/central-syslog/commit/ac4eec0ce1745b394ed61ac4d480d52ba223652f