### PR TITLE
Avoid duplicate dirs in the image list

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -55,11 +55,11 @@ jobs:
                                  "$GITHUB_SHA" |
                         egrep "^$ORG_DIR/" |
                         cut -d/ -f -2 |
+                        sort |
+                        uniq |
                         xargs -I {} find . -type d \
                                            -wholename ./{} \
-                                           -printf "%P\n" |
-                        sort |
-                        uniq)
+                                           -printf "%P\n")
           else
                # List all image root dirs. Example value:
                # "opensciencegrid/vo-frontend opensciencegrid/ospool-cm"

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -57,7 +57,9 @@ jobs:
                         cut -d/ -f -2 |
                         xargs -I {} find . -type d \
                                            -wholename ./{} \
-                                           -printf "%P\n")
+                                           -printf "%P\n" |
+                        sort |
+                        uniq)
           else
                # List all image root dirs. Example value:
                # "opensciencegrid/vo-frontend opensciencegrid/ospool-cm"


### PR DESCRIPTION
Need this before submitting the `ospool-ap` PR so we don't get 90+ repeat image builds