### PR TITLE
Consolidate per-image jobs (SOFTWARE-5098)

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -87,11 +87,18 @@ jobs:
       matrix:
         image: ${{ fromJson(needs.build-image-list.outputs.images) }}
         yum_repo: ['development', 'testing', 'release']
-        osg_series: ['3.5', '3.6']
     steps:
-      - uses: opensciencegrid/build-container-action@v0.3.0
+      - name: Build ${{ matrix.image }}:3.5-${{ matrix.yum_repo }}
+        uses: opensciencegrid/build-container-action@v0.3.0
         with:
-          osg_series: ${{ matrix.osg_series }}
+          osg_series: 3.5
+          repo: ${{ matrix.yum_repo }}
+          context: ${{ matrix.image }}
+
+      - name: Build ${{ matrix.image }}:3.6-${{ matrix.yum_repo }}
+        uses: opensciencegrid/build-container-action@v0.3.0
+        with:
+          osg_series: 3.6
           repo: ${{ matrix.yum_repo }}
           context: ${{ matrix.image }}
 

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -107,21 +107,135 @@ jobs:
       fail-fast: false
       matrix:
         image: ${{ fromJson(needs.build-image-list.outputs.images) }}
-        yum_repo: ['development', 'testing', 'release']
-        osg_series: ['3.5', '3.6']
-        registry:
-          - url: hub.opensciencegrid.org
-            username: OSG_HARBOR_ROBOT_USER
-            password: OSG_HARBOR_ROBOT_PASSWORD
-          - url: docker.io
-            username: DOCKER_USERNAME
-            password: DOCKER_PASSWORD
     steps:
-      - uses: opensciencegrid/push-container-action@v0.5.0
+      - name: Push to Harbor (3.5-development)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
         with:
-          repo: ${{ matrix.yum_repo}}
-          osg_series: ${{ matrix.osg_series }}
+          repo: development
+          osg_series: 3.5
           context: ${{ matrix.image }}
-          registry_url: ${{ matrix.registry.url }}
-          registry_user: ${{ secrets[matrix.registry.username] }}
-          registry_pass: ${{ secrets[matrix.registry.password] }}
+          registry_url: hub.opensciencegrid.org
+          registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
+          registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
+
+      - name: Push to Harbor (3.5-testing)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
+        with:
+          repo: testing
+          osg_series: 3.5
+          context: ${{ matrix.image }}
+          registry_url: hub.opensciencegrid.org
+          registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
+          registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
+
+      - name: Push to Harbor (3.5-release)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
+        with:
+          repo: release
+          osg_series: 3.5
+          context: ${{ matrix.image }}
+          registry_url: hub.opensciencegrid.org
+          registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
+          registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
+
+      - name: Push to Harbor (3.6-development)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
+        with:
+          repo: development
+          osg_series: 3.6
+          context: ${{ matrix.image }}
+          registry_url: hub.opensciencegrid.org
+          registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
+          registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
+
+      - name: Push to Harbor (3.6-testing)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
+        with:
+          repo: testing
+          osg_series: 3.6
+          context: ${{ matrix.image }}
+          registry_url: hub.opensciencegrid.org
+          registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
+          registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
+
+      - name: Push to Harbor (3.6-release)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
+        with:
+          repo: release
+          osg_series: 3.6
+          context: ${{ matrix.image }}
+          registry_url: hub.opensciencegrid.org
+          registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
+          registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
+
+      - name: Push to Docker Hub (3.5-development)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
+        with:
+          repo: development
+          osg_series: 3.5
+          context: ${{ matrix.image }}
+          registry_url: docker.io
+          registry_user: ${{ secrets.DOCKER_USERNAME }}
+          registry_pass: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push to Docker Hub (3.5-testing)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
+        with:
+          repo: testing
+          osg_series: 3.5
+          context: ${{ matrix.image }}
+          registry_url: docker.io
+          registry_user: ${{ secrets.DOCKER_USERNAME }}
+          registry_pass: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push to Docker Hub (3.5-release)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
+        with:
+          repo: release
+          osg_series: 3.5
+          context: ${{ matrix.image }}
+          registry_url: docker.io
+          registry_user: ${{ secrets.DOCKER_USERNAME }}
+          registry_pass: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push to Docker Hub (3.6-development)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
+        with:
+          repo: development
+          osg_series: 3.6
+          context: ${{ matrix.image }}
+          registry_url: docker.io
+          registry_user: ${{ secrets.DOCKER_USERNAME }}
+          registry_pass: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push to Docker Hub (3.6-testing)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
+        with:
+          repo: testing
+          osg_series: 3.6
+          context: ${{ matrix.image }}
+          registry_url: docker.io
+          registry_user: ${{ secrets.DOCKER_USERNAME }}
+          registry_pass: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push to Docker Hub (3.6-release)
+        if: always()
+        uses: opensciencegrid/push-container-action@v0.5.0
+        with:
+          repo: release
+          osg_series: 3.6
+          context: ${{ matrix.image }}
+          registry_url: docker.io
+          registry_user: ${{ secrets.DOCKER_USERNAME }}
+          registry_pass: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -89,6 +89,7 @@ jobs:
         yum_repo: ['development', 'testing', 'release']
     steps:
       - name: Build ${{ matrix.image }}:3.5-${{ matrix.yum_repo }}
+        continue-on-error: ${{ matrix.yum_repo == 'development' }}
         uses: opensciencegrid/build-container-action@v0.3.0
         with:
           osg_series: 3.5
@@ -96,6 +97,7 @@ jobs:
           context: ${{ matrix.image }}
 
       - name: Build ${{ matrix.image }}:3.6-${{ matrix.yum_repo }}
+        continue-on-error: ${{ matrix.yum_repo == 'development' }}
         uses: opensciencegrid/build-container-action@v0.3.0
         with:
           osg_series: 3.6


### PR DESCRIPTION
This consolidates a number of jobs so that the GHA UI doesn't barf (though I do have a ticket open with them about it):

- Different release series builds into a single build job but still runs separate `(development, testing, release)` per image. I decided to keep it this way so that we can allow the `development` builds to fail without preventing us from pushing `testing` and `release` images
- All pushes for a given image into a single push job

Test run here: https://github.com/brianhlin/osg-images/actions/runs/2035965206. Spot-checked builds and it looks like they're selecting the appropriate 3.5 vs 3.6 base images in each build. Pushes fail (as expected) because I didn't set up the relevant secrets but they at least look like they're trying to pull down the relevant build caches