### PR TITLE
break out build-image-list.sh and build contrib images (SOFTWARE-5013)

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -29,51 +29,8 @@ jobs:
 
       - id: image-list
         run: |
-          ORG_DIR=opensciencegrid
-          # Get the list of files changed based on the type of event
-          # kicking off the GHA:
-          # 1. For the main branch, diff the previous state of main vs
-          #    the current commit
-          # 2. For other branches (i.e., on someone's fork), diff main
-          #    vs the current commit
-          # 3. For PRs, diff the base ref vs the current commit
-          # 4. For everything else (e.g., dispatches), build all images
-          if [[ $GITHUB_EVENT_NAME == 'pull_request' ]] ||
-             [[ $GITHUB_EVENT_NAME == 'push' ]]; then
-               if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
-                   BASE=$(git merge-base origin/$GITHUB_BASE_REF HEAD)
-               elif [[ $GITHUB_REF == 'refs/heads/main' ]]; then
-                   BASE=${{github.event.before}}
-               else
-                   BASE=origin/main
-               fi
-               # List image root dirs where files have changed and the
-               # root dir exists. Example value:
-               # "opensciencegrid/vo-frontend opensciencegrid/ospool-cm"
-               images=$(git diff --name-only \
-                                 "$BASE" \
-                                 "$GITHUB_SHA" |
-                        egrep "^$ORG_DIR/" |
-                        cut -d/ -f -2 |
-                        sort |
-                        uniq |
-                        xargs -I {} find . -type d \
-                                           -wholename ./{} \
-                                           -printf "%P\n")
-          else
-               # List all image root dirs. Example value:
-               # "opensciencegrid/vo-frontend opensciencegrid/ospool-cm"
-               images=$(find $ORG_DIR -mindepth 1 \
-                                      -maxdepth 1 \
-                                      -type d \
-                                      -printf "$ORG_DIR/%P\n")
-          fi
-
-          # Ensure that the generated JSON array has a member,
-          # otherwise GHA will throw an error about an empty matrix
-          # vector in subsequent steps
-          image_json=$(echo -n "${images:-dummy}" | jq -Rcs '.|split("\n")')
-          echo "::set-output name=json::$image_json"
+          export GITHUB_EVENT_BEFORE=${{github.event.before}}
+          ./build-image-list.sh
 
   build:
     runs-on: ubuntu-latest

--- a/build-image-list.sh
+++ b/build-image-list.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# GITHUB_EVENT_BEFORE provided in env
+
+ORG_DIR=opensciencegrid
+CONTRIB=contrib
+# Get the list of files changed based on the type of event
+# kicking off the GHA:
+# 1. For the main branch, diff the previous state of main vs
+#    the current commit
+# 2. For other branches (i.e., on someone's fork), diff main
+#    vs the current commit
+# 3. For PRs, diff the base ref vs the current commit
+# 4. For everything else (e.g., dispatches), build all images
+if [[ $GITHUB_EVENT_NAME == 'pull_request' ]] ||
+   [[ $GITHUB_EVENT_NAME == 'push' ]]; then
+     if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
+         BASE=$(git merge-base origin/$GITHUB_BASE_REF HEAD)
+     elif [[ $GITHUB_REF == 'refs/heads/main' ]]; then
+         BASE=$GITHUB_EVENT_BEFORE
+     else
+         BASE=origin/main
+     fi
+     # List image root dirs where files have changed and the
+     # root dir exists. Example value:
+     # "opensciencegrid/vo-frontend opensciencegrid/ospool-cm"
+     images=$(git diff --name-only \
+                       "$BASE" \
+                       "$GITHUB_SHA" |
+              egrep "^$ORG_DIR/" |
+              cut -d/ -f -2 |
+              sort |
+              uniq |
+              xargs -I {} find . -type d \
+                                 -wholename ./{} \
+                                 -printf "%P\n")
+else
+     # List all image root dirs. Example value:
+     # "opensciencegrid/vo-frontend opensciencegrid/ospool-cm"
+     images=$(find $ORG_DIR -mindepth 1 \
+                            -mindepth 1 \
+                            -maxdepth 1 \
+                            -type d \
+                            -printf "%p\n")
+fi
+
+# Ensure that the generated JSON array has a member,
+# otherwise GHA will throw an error about an empty matrix
+# vector in subsequent steps
+image_json=$(echo -n "${images:-dummy}" | jq -Rcs '.|split("\n")')
+echo "::set-output name=json::$image_json"

--- a/build-image-list.sh
+++ b/build-image-list.sh
@@ -27,7 +27,7 @@ if [[ $GITHUB_EVENT_NAME == 'pull_request' ]] ||
      images=$(git diff --name-only \
                        "$BASE" \
                        "$GITHUB_SHA" |
-              egrep "^$ORG_DIR/" |
+              egrep -e "^$ORG_DIR/" -e "^$CONTRIB/" |
               cut -d/ -f -2 |
               sort |
               uniq |
@@ -37,7 +37,7 @@ if [[ $GITHUB_EVENT_NAME == 'pull_request' ]] ||
 else
      # List all image root dirs. Example value:
      # "opensciencegrid/vo-frontend opensciencegrid/ospool-cm"
-     images=$(find $ORG_DIR -mindepth 1 \
+     images=$(find $ORG_DIR $CONTRIB \
                             -mindepth 1 \
                             -maxdepth 1 \
                             -type d \

--- a/contrib/fts-server/Dockerfile
+++ b/contrib/fts-server/Dockerfile
@@ -1,0 +1,1 @@
+Dockerfile.3.10-osg36


### PR DESCRIPTION
Well it's a first step anyway.

This moves the large build-image-list shell block out of the gha workflow into a separate script, which is also tweaked to include the contrib images.

For now I'm dropping in a Dockerfile symlink, but I would like to provide a mechanism to handle this type of situation where you might have multiple and want to specify the dockerfile filename.

In particular, I think we'd need to add an optional `dockerfile` option to opensciencegrid/build-container-action around [here](https://github.com/opensciencegrid/build-container-action/blob/main/action.yml#L12-L15), which would then get passed in as the `file` option to docker/build-push-action [here](https://github.com/docker/build-push-action/blob/master/action.yml#L37-L39).

In theory we'd add that option to the per-image-dir json customization file.