### PR TITLE
OSDF Collector

### DIFF
--- a/opensciencegrid/osdf-collector/Dockerfile
+++ b/opensciencegrid/osdf-collector/Dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_OSG_SERIES=3.6
+ARG BASE_YUM_REPO=testing
+
+FROM opensciencegrid/software-base:${BASE_OSG_SERIES}-el8-${BASE_YUM_REPO}
+LABEL maintainer "OSG Software <help@opensciencegrid.org>"
+
+# Previous args have gone out of scope
+ARG BASE_OSG_SERIES=3.6
+ARG BASE_YUM_REPO=testing
+
+RUN yum install -y condor \
+    && yum clean all \
+    && rm -rf /var/cache/yum/
+
+COPY etc/ /etc/

--- a/opensciencegrid/osdf-collector/Dockerfile
+++ b/opensciencegrid/osdf-collector/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer "OSG Software <help@opensciencegrid.org>"
 ARG BASE_OSG_SERIES=3.6
 ARG BASE_YUM_REPO=testing
 
-RUN yum install -y condor \
+RUN yum install -y condor rsyslog \
     && yum clean all \
     && rm -rf /var/cache/yum/
 

--- a/opensciencegrid/osdf-collector/LICENSE
+++ b/opensciencegrid/osdf-collector/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/opensciencegrid/osdf-collector/README.md
+++ b/opensciencegrid/osdf-collector/README.md
@@ -1,0 +1,5 @@
+# OSDF Collector
+
+Docker image for the central collector of the OSDF
+
+Example service instance is at: https://osdf-collector.osg-htc.org

--- a/opensciencegrid/osdf-collector/etc/condor/config.d/50-osdf-collector.conf
+++ b/opensciencegrid/osdf-collector/etc/condor/config.d/50-osdf-collector.conf
@@ -1,0 +1,38 @@
+
+###
+# Configurations for the OSDF collector
+###
+
+# We only need the collector in this container
+DAEMON_LIST = COLLECTOR
+
+# This is the name in the collector ad sent to collector.opensciencegrid.org
+COLLECTOR_NAME=OSDF-Collector
+
+# As of the time of writing, 3DES is still in the default security parameters.
+SEC_DEFAULT_CRYPTO_METHODS = AES
+
+# Enable strong security
+use security:strong
+
+# Cert and key in Kubernetes-style formats
+AUTH_SSL_SERVER_CERTFILE = /etc/condor/pki/tls.crt
+AUTH_SSL_SERVER_KEYFILE  = /etc/condor/pki/tls.key
+
+# Authorization mapfile.
+CERTIFICATE_MAPFILE=/etc/condor/mapfile
+
+# The mapfile should limit the mapped OSDF caches to *@osg-htc.org
+UID_DOMAIN = osg-htc.org
+ALLOW_DAEMON=*@osg-htc.org
+
+# Limit the kinds of ads we are permitting.
+COLLECTOR_REQUIREMENTS = ( TARGET.MyType == "OSDFServer" || TARGET.MyType == "OSDFNamespace" || TARGET.MyType == "Collector" )
+
+# Forward OSDF ads to the CE collector
+CONDOR_VIEW_HOST=collector.opensciencegrid.org:9619
+UPDATE_VIEW_COLLECTOR_WITH_TCP=True
+
+# Not strictly necessary - but convenient for when you exec into the container:
+COLLECTOR_HOST=localhost
+CONDOR_HOST=localhost

--- a/opensciencegrid/osdf-collector/etc/condor/config.d/50-osdf-collector.conf
+++ b/opensciencegrid/osdf-collector/etc/condor/config.d/50-osdf-collector.conf
@@ -36,3 +36,6 @@ UPDATE_VIEW_COLLECTOR_WITH_TCP=True
 # Not strictly necessary - but convenient for when you exec into the container:
 COLLECTOR_HOST=localhost
 CONDOR_HOST=localhost
+
+# Improve default logging to match our syslog scripts
+ALL_DEBUG=D_CAT,D_SUB_SECOND,D_PID

--- a/opensciencegrid/osdf-collector/etc/condor/mapfile
+++ b/opensciencegrid/osdf-collector/etc/condor/mapfile
@@ -1,0 +1,2 @@
+# Allow the OSDF services issuer to create usernames directly.
+SCITOKENS /^https\:\/\/osg\-htc\.org\/osdf,OSDF-(.*)@osg-htc.org$/ $1@osg-htc.org

--- a/opensciencegrid/osdf-collector/etc/condor/mapfile
+++ b/opensciencegrid/osdf-collector/etc/condor/mapfile
@@ -1,2 +1,2 @@
 # Allow the OSDF services issuer to create usernames directly.
-SCITOKENS /^https\:\/\/osg\-htc\.org\/osdf,OSDF-(.*)@osg-htc.org$/ $1@osg-htc.org
+SCITOKENS ^https\:\/\/osg\-htc\.org\/osdf,OSDF-(.*)@osg-htc.org$ \1@osg-htc.org

--- a/opensciencegrid/osdf-collector/etc/rsyslog.conf
+++ b/opensciencegrid/osdf-collector/etc/rsyslog.conf
@@ -1,0 +1,149 @@
+# Listen to the traditional syslog Unix socket.
+module(
+load="imuxsock"
+SysSock.Unlink="off"
+SysSock.UsePIDFromSystem="on"
+)
+
+# Look for condor logfiles
+module(
+load="imfile"
+PollingInterval="1"
+)
+
+# Condor-specific logging format
+template(name="Condor_SyslogProtocol23Format" type="list")
+{
+    property(name="$.year")
+    constant(value="-")
+    property(name="$.month")
+    constant(value="-")
+    property(name="$.day")
+    constant(value="T")
+    property(name="$.hour")
+    constant(value=":")
+    property(name="$.min")
+    constant(value=":")
+    property(name="$.sec")
+    constant(value="Z ")
+    property(name="app-name")
+    constant(value=" ")
+    property(name="msg"
+             regex.type="ERE"
+             regex.expression="(^[[:digit:][:space:]/:.]+ \\(pid\\:([[:digit:]]+)\\))"
+             regex.submatch="2"
+            )
+    constant(value=" - [")
+    property(name="$.structure")
+    constant(value="] ")
+    property(name="msg"
+             regex.type="ERE"
+             regex.expression="(^[[:digit:][:space:]/:.]+ \\(pid\\:[[:digit:]]+\\) \\(D_[[:upper:]_|]+(:1|:2)?\\)) (.*)"
+             regex.submatch="3"
+            )
+    constant(value="\n")
+}
+
+
+template(name="Proc_SyslogProtocol23Format" type="list")
+{
+    property(name="$.year")
+    constant(value="-")
+    property(name="$.month")
+    constant(value="-")
+    property(name="$.day")
+    constant(value="T")
+    property(name="$.hour")
+    constant(value=":")
+    property(name="$.min")
+    constant(value=":")
+    property(name="$.sec")
+    constant(value="Z ")
+    property(name="app-name")
+    constant(value=" - - [] ")
+    property(name="msg"
+             regex.type="ERE"
+             regex.expression="(^[[:digit:]]{2}/[[:digit:]]{2}/[[:digit:]]{2} [[:digit:]]{2}\\:[[:digit:]]{2}\\:[[:digit:]]{2} \\: (.*))"
+             regex.submatch="2"
+            )
+    constant(value="\n")
+}
+
+ruleset(name="CondorTimestamp") {
+  set $.year = "20" & field(field($msg, 32, 1), 47, 3);
+  set $.month = field($msg, 47, 1);
+  set $.day = field($msg, 47, 2);
+
+  set $.time = field($msg, 32, 2);
+  set $.hour = field($.time, 58, 1);
+  set $.min = field($.time, 58, 2);
+  set $.sec = field($.time, 58, 3);
+}
+
+ruleset(name="ProcLog") {
+  call CondorTimestamp
+  action(type="omfile" file="/dev/stdout"
+         template="Proc_SyslogProtocol23Format"
+        )
+}
+
+ruleset(name="CondorLog") {
+
+  call CondorTimestamp
+
+  set $.extra!cat = replace(replace(field($msg, 32, 4), "(", ""), ")", "");
+  if ($.extra!slot != "") then {
+    set $.structure = "cat=\"" & $.extra!cat & "\" slot=\"" & $.extra!slot & "\"";
+  } else {
+    set $.structure = "cat=\"" & $.extra!cat & "\"";
+  }
+
+  action(type="omfile" file="/dev/stdout"
+        template="Condor_SyslogProtocol23Format"
+        )
+
+  call forwardCondor
+}
+
+module(load="builtin:omfile" Template="Glidein_SyslogProtocol23Format")
+
+# ProcLog  SharedPortLog
+input(
+type="imfile"
+File="/var/log/condor/MasterLog"
+Tag="condor_master"
+Facility="local2"
+Severity="info"
+startmsg.regex="(^[[:digit:][:space:]/:.]+ \\(pid)"
+ruleset="CondorLog"
+)
+
+input(
+type="imfile"
+File="/var/log/condor/CollectorLog"
+Tag="condor_collector"
+Facility="local2"
+startmsg.regex="(^[[:digit:][:space:]/:.]+ \\(pid)"
+ruleset="CondorLog"
+)
+
+input(
+type="imfile"
+File="/var/log/condor/SharedPortLog"
+Tag="condor_shared_port"
+Facility="local2"
+startmsg.regex="(^[[:digit:][:space:]/:.]+ \\(pid)"
+addMetadata="on"
+ruleset="CondorLog"
+)
+
+input(
+type="imfile"
+File="/var/log/condor/ProcLog"
+Tag="condor_procd"
+Facility="local2"
+ruleset="ProcLog"
+)
+
+# Log all messages to the syslog daemon's stdout.
+*.* /dev/stdout

--- a/opensciencegrid/osdf-collector/etc/supervisord.d/htcondor.conf
+++ b/opensciencegrid/osdf-collector/etc/supervisord.d/htcondor.conf
@@ -1,0 +1,4 @@
+[program:htcondor]
+command=/usr/sbin/condor_master -f
+autorestart=true
+startsecs=20

--- a/opensciencegrid/osdf-collector/etc/supervisord.d/rsyslogd.conf
+++ b/opensciencegrid/osdf-collector/etc/supervisord.d/rsyslogd.conf
@@ -1,0 +1,12 @@
+[program:rsyslogd]
+directory=/
+command=/usr/sbin/rsyslogd -n
+autorestart=true
+stdout_logfile=/proc/self/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/proc/self/fd/2
+stderr_logfile_maxbytes=0
+
+# Lower priority means its started first / shut down last
+# We want to have logging working for when condor starts.
+priority=100


### PR DESCRIPTION
This is a simple container meant to run a HTCondor collector on behalf of the OSDF.

Collector status information in a container is an old idea; we have about 5 of the OSDF cache installs reporting to collector.opensciencegrid.org currently.  This represents a fresh approach where we'll have a combination of topology and the shovelers pushing ads to the collector, then have a dedicated OSDF webapp doing matchmaking between clients and sites.  The long-term goal is to provide an abstraction layer between OSDF and other OSG services so one could setup a standalone OSDF without any other OSG-provided service (turning OSDF more into a software product).

But for now, just a collector.

(Oh, and a collector with rsyslog integration so the container logs "do the right thing")