### PR TITLE
Copy signing keys and fix perms

### DIFF
--- a/opensciencegrid/central-collector/Dockerfile
+++ b/opensciencegrid/central-collector/Dockerfile
@@ -28,6 +28,7 @@ RUN mkdir /var/lib/condor-ce/webapp
 COPY etc/supervisord.d/*      /etc/supervisord.d/
 COPY etc/condor-ce/config.d/* /etc/condor-ce/config.d/
 COPY etc/httpd/conf.d/*       /etc/httpd/conf.d/
+COPY etc/osg/image-init.d/*   /etc/osg/image-init.d/
 COPY auto-reload.sh           /usr/local/sbin/
 
 RUN  chmod a+x /usr/local/sbin/auto-reload.sh

--- a/opensciencegrid/central-collector/etc/osg/image-init.d/50-collector-tokens.sh
+++ b/opensciencegrid/central-collector/etc/osg/image-init.d/50-collector-tokens.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# set up credentials
+if [ ! -e /etc/condor/idkeys.d ]; then
+     echo "Please mount /etc/condor/idkeys.d/ with the signing key"
+     echo "For compatibility reasons, exiting successful; this may change in the future"
+     return
+fi
+
+echo "Installing HTCondor credentials..."
+cd /etc/condor/idkeys.d
+for FILE in *; do
+    install -o root -g root -m 0600 $FILE /etc/condor/passwords.d/$FILE
+done


### PR DESCRIPTION
If signing keys are present in the container, make a copy of them into the expected location.  This will enable us to make IDTOKENS for the central-collector which are valid between restarts.