### PR TITLE
Handle values without a PrimaryName

### DIFF
--- a/opensciencegrid/mailchimp-sync/mailchimp-sync/sync.py
+++ b/opensciencegrid/mailchimp-sync/mailchimp-sync/sync.py
@@ -125,7 +125,7 @@ def comanage_find_users(users):
     if resp.status_code != 200:
         raise ApiError('Cannot fetch names: {}'.format(resp.status_code))
     for n in resp.json()['Names']:
-        if n['PrimaryName'] == True:
+        if n.get('PrimaryName', False) == True:
             pid = n['Person']['Id']
             if pid in co_users:
                 co_users[pid]['firstname'] = n['Given']


### PR DESCRIPTION
I'm seeing jobs fail with

```
Traceback (most recent call last):
  File "sync.py", line 326, in <module>
    main()
  File "sync.py", line 290, in main
    comanage_find_users(users)
  File "sync.py", line 128, in comanage_find_users
    if n['PrimaryName'] == True:
KeyError: 'PrimaryName'
```

I'm assuming that `n` is a dict