### PR TITLE
Update CI to use opensciencegrid/build-container-action@v0.3.1

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -90,7 +90,7 @@ jobs:
     steps:
       - name: Build ${{ matrix.image }}:3.6-${{ matrix.yum_repo }}
         continue-on-error: ${{ matrix.yum_repo == 'development' }}
-        uses: opensciencegrid/build-container-action@v0.3.0
+        uses: opensciencegrid/build-container-action@v0.3.1
         with:
           osg_series: 3.6
           repo: ${{ matrix.yum_repo }}


### PR DESCRIPTION
push-container-action@v0.5.0 expects underscores to separate cache key elements
https://github.com/opensciencegrid/push-container-action/blob/v0.5.0/action.yml#L73

build-container-action@v0.3.0 uses dashes
https://github.com/opensciencegrid/build-container-action/blob/v0.3.0/action.yml#L57

Switch build-container-action to v0.3.1 to use underscores
https://github.com/opensciencegrid/build-container-action/blob/v0.3.1/action.yml#L57