### PR TITLE
Update CI to use opensciencegrid/build-container-action@v0.4.1

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -90,7 +90,7 @@ jobs:
     steps:
       - name: Build ${{ matrix.image }}:3.6-${{ matrix.yum_repo }}
         continue-on-error: ${{ matrix.yum_repo == 'development' }}
-        uses: opensciencegrid/build-container-action@v0.3.1
+        uses: opensciencegrid/build-container-action@v0.4.1
         with:
           osg_series: 3.6
           repo: ${{ matrix.yum_repo }}


### PR DESCRIPTION
Includes fix for extra curly brace from https://github.com/opensciencegrid/build-container-action/commit/7791700dbfd6b7ec17add110d4bd1a66e9cc543f
```
Run actions/cache@v2
  with:
    path: /tmp/.buildx-cache
    key: gwms-factory}_3.6_development_buildx_ebb5f1c8b5dec9b8f427a6c72d07948e0db2fc86_4940437215
Cache not found for input keys: gwms-factory}_3.6_development_buildx_ebb5f1c8b5dec9b8f427a6c72d07948e0db2fc86_4940437215
```