### PR TITLE
Support running frontier-squid container from unprivileged apptainer or OKD

### DIFF
--- a/opensciencegrid/frontier-squid/Dockerfile
+++ b/opensciencegrid/frontier-squid/Dockerfile
@@ -46,6 +46,10 @@ COPY start-frontier-squid.sh /usr/sbin/
 COPY squid-customize.sh /etc/squid/customize.sh
 COPY customize.d/* /etc/squid/customize.d/
 COPY supervisor-frontier-squid.conf /etc/supervisord.d/40-frontier-squid.conf
+# For OKD, which runs as non-root user and root group
+RUN chgrp root /run/squid /etc/squid /var/cache/squid /var/log/squid
+RUN chmod g+w /run/squid /etc/squid /var/cache/squid /var/log/squid
+RUN chmod g+w /etc/cron.d /etc/cron.d/frontier-squid.cron
 
 EXPOSE 3128
 

--- a/opensciencegrid/frontier-squid/README.md
+++ b/opensciencegrid/frontier-squid/README.md
@@ -9,12 +9,27 @@ The image is built according to the
 Usage
 -----
 
-To run with the defaults:
+To run with the defaults on docker or podman:
 
 ```bash
 docker run --rm --name frontier-squid \
   -p 3128:3128 opensciencegrid/frontier-squid:3.6-release
 ```
+
+Running docker or podman with a `-u` option to start as a non-root user
+is also supported.
+
+To run with the default settings on apptainer:
+
+```bash
+apptainer run --writable-tmpfs \
+  -B /scratch/squid/cache:/var/cache/squid \
+  -B /scratch/squid/log:/var/log/squid \
+  docker://opensciencegrid/frontier-squid:3.6-release
+```
+
+Replace `/scratch/squid` with a path to wherever you have a filesystem
+large enough to hold the squid cache and logs.
 
 See [our documentation](https://opensciencegrid.org/technology/policy/container-release/#tags) for details of our docker
 image tags.

--- a/opensciencegrid/frontier-squid/start-frontier-squid.sh
+++ b/opensciencegrid/frontier-squid/start-frontier-squid.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 # Wrapper script for starting & stopping frontier squid from supervisord
 
+STARTSTOPSCRIPT=/etc/init.d/frontier-squid
+if [ "$(id -u)" != 0 ]; then
+    STARTSTOPSCRIPT=/usr/sbin/fn-local-squid.sh
+    # crond is run under fakeroot, works better when jobs run as "root"
+    # assumes running with a writable overlay
+    sed -i 's/ squid / root /' /etc/cron.d/frontier-squid.cron
+fi
+
 # stop squid if supervisord sends a TERM signal
-trap "/etc/init.d/frontier-squid stop" TERM
+trap "$STARTSTOPSCRIPT stop" TERM
 
 # we tell squid to run in the foreground, but by telling the
 #   shell to start it in the background and waiting for it we
 #   prevent the shell from ignoring signals
 export SQUID_START_ARGS="--foreground"
-/etc/init.d/frontier-squid start &
+$STARTSTOPSCRIPT start &
 wait


### PR DESCRIPTION
This builds on opensciencegrid/docker-software-base#70 to enable the OSG frontier-squid container to be run from Apptainer or OKD.