### PR TITLE
gwms-factory: Add msmtp package

### DIFF
--- a/opensciencegrid/gwms-factory/Dockerfile
+++ b/opensciencegrid/gwms-factory/Dockerfile
@@ -15,6 +15,7 @@ RUN useradd feosgospool
 RUN    yum -y install \
          git \
          glideinwms-factory \
+         msmtp \
          vo-client \
          vim-enhanced \
     && pip3 install --no-cache-dir PyYAML \


### PR DESCRIPTION
Of the outbound email options, msmtp seems like the best. Both sSMTP and esmtp are no longer maintained.