### PR TITLE
SOFTWARE-5245-frontier-squid-directory-permissions

### DIFF
--- a/opensciencegrid/frontier-squid/10-chown-mount-points.sh
+++ b/opensciencegrid/frontier-squid/10-chown-mount-points.sh
@@ -9,7 +9,7 @@ GROUP=root
 EXIT_CODE=13
 
 for squid_dir in ${SQUID_DIRS[@]}; do
-  if ! find $squid_dir | xargs chown $OWNER:$GROUP ; then 
+  if ! chown -R $OWNER:$GROUP $squid_dir; then 
     echo "Error: Unable to set ownership of mounted $squid_dir to $OWNER:$GROUP. frontier-squid is unable to run."
     exit $EXIT_CODE
   fi

--- a/opensciencegrid/frontier-squid/10-chown-mount-points.sh
+++ b/opensciencegrid/frontier-squid/10-chown-mount-points.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Attempt to recursively set the ownership of /var/log/squid and /var/cache/squid to
+# squid:root. Exit on failure, since incorrect ownership prevents squid from running.
+
+SQUID_DIRS=(/var/log/squid /var/cache/squid)
+OWNER=squid
+GROUP=root
+EXIT_CODE=13
+
+for squid_dir in ${SQUID_DIRS[@]}; do
+  if ! find $squid_dir | xargs chown $OWNER:$GROUP ; then 
+    echo "Error: Unable to set ownership of mounted $squid_dir to $OWNER:$GROUP. frontier-squid is unable to run."
+    exit $EXIT_CODE
+  fi
+done

--- a/opensciencegrid/frontier-squid/Dockerfile
+++ b/opensciencegrid/frontier-squid/Dockerfile
@@ -46,6 +46,7 @@ COPY start-frontier-squid.sh /usr/sbin/
 COPY squid-customize.sh /etc/squid/customize.sh
 COPY customize.d/* /etc/squid/customize.d/
 COPY supervisor-frontier-squid.conf /etc/supervisord.d/40-frontier-squid.conf
+COPY 10-chown-mount-points.sh /etc/osg/image-init.d/
 # For OKD, which runs as non-root user and root group
 RUN chgrp root /run/squid /etc/squid /var/cache/squid /var/log/squid
 RUN chmod g+w /run/squid /etc/squid /var/cache/squid /var/log/squid


### PR DESCRIPTION
Add init script that chowns mounted squid runtime directories, and exits on failure