### PR TITLE
Do not run `adduser` if we have no users to add

### DIFF
--- a/opensciencegrid/xrootd-standalone/image-config.d/10-add-users.sh
+++ b/opensciencegrid/xrootd-standalone/image-config.d/10-add-users.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 if [ -f '/usr/share/osg/voms-mapfile-default' ]; then
-    grep '".*" .*' /usr/share/osg/voms-mapfile-default  | awk '{print $NF}' | xargs -n1 adduser
+    grep '".*" .*' /usr/share/osg/voms-mapfile-default  | awk '{print $NF}' | xargs --no-run-if-empty -n1 adduser
 fi
 if [ -f '/etc/grid-security/grid-mapfile' ]; then
-    grep '".*" .*' /etc/grid-security/grid-mapfile | awk '{print $NF}' | xargs -n1 adduser
+    grep '".*" .*' /etc/grid-security/grid-mapfile | awk '{print $NF}' | xargs --no-run-if-empty -n1 adduser
 fi
 if [ -f '/etc/grid-security/voms-mapfile' ]; then
-    grep '".*" .*' /etc/grid-security/voms-mapfile | awk '{print $NF}' | xargs -n1 adduser
+    grep '".*" .*' /etc/grid-security/voms-mapfile | awk '{print $NF}' | xargs --no-run-if-empty -n1 adduser
 fi


### PR DESCRIPTION
From the xargs manpage, the command is run once even if there is no input, unless `--no-run-if-empty` is passed.