### PR TITLE
osgstorage-redirector: Move from EL7 to EL8

### DIFF
--- a/opensciencegrid/osgstorage-redirector/Dockerfile
+++ b/opensciencegrid/osgstorage-redirector/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_OSG_SERIES=3.6
 ARG BASE_YUM_REPO=release
 
-FROM hub.opensciencegrid.org/opensciencegrid/software-base:$BASE_OSG_SERIES-el7-$BASE_YUM_REPO
+FROM hub.opensciencegrid.org/opensciencegrid/software-base:$BASE_OSG_SERIES-el8-$BASE_YUM_REPO
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 


### PR DESCRIPTION
Moving to EL9 would add OpenSSL 3, which needs a bit more care. Moving to EL8 would be a good intermediate step.