### PR TITLE
On CE dashboard, put GlideinRunning data on the bottom.

### DIFF
--- a/opensciencegrid/ospool-ganglia/view_chtc-spark.json
+++ b/opensciencegrid/ospool-ganglia/view_chtc-spark.json
@@ -6,8 +6,10 @@
      {"regex":"chtc-spark-ce1.svc.opensciencegrid.org"}
        ],
        "metric_regex":[
-     {"regex":"^Glideins(Running|Idle)$"}
-       ],
+	 {"regex":"^GlideinsRunning$"},
+	 {"regex":"^GlideinsIdle$"}
+	   ],
+       "sortit":"false",
        "graph_type":"stack",
        "vertical_label":"glideins",
        "title":"Glideins Running vs Idle"


### PR DESCRIPTION
Miron requested that on the CE Dashboard graphs, the GlideinsRunning data series should be on the bottom of the stacked graph, instead of GlideinsIdle.