### PR TITLE
gracc-apel: Switch python client to opensearch-py

### DIFF
--- a/opensciencegrid/gracc-apel/Dockerfile
+++ b/opensciencegrid/gracc-apel/Dockerfile
@@ -9,7 +9,7 @@ ARG BASE_OS
 
 # install dependencies
 RUN yum -y install python3 python3-pip && \
-  pip3 install elasticsearch-dsl requests && \
+  pip3 install opensearch-py requests && \
   pip3 install argo-ams-library
 RUN yum -y install http://rpm-repo.argo.grnet.gr/ARGO/devel/centos7/python-argo-ams-library-0.5.5-20210415071520.ff0c536.$BASE_OS.noarch.rpm
 

--- a/opensciencegrid/gracc-apel/apel_report.py
+++ b/opensciencegrid/gracc-apel/apel_report.py
@@ -2,9 +2,9 @@
 
 # GRACC-based APEL reporting script; run from docker-run.sh
 
-import elasticsearch
-from elasticsearch_dsl import Search, A, Q
 #import logging
+import opensearchpy
+from opensearchpy import Search, A, Q
 import datetime
 import dateutil.relativedelta
 import operator
@@ -17,7 +17,7 @@ from math import isclose
 
 
 #logging.basicConfig(level=logging.WARN)
-es = elasticsearch.Elasticsearch(
+es = opensearchpy.OpenSearch(
         ['https://gracc.opensciencegrid.org/q'],
         timeout=300, use_ssl=True, verify_certs=True,
         ca_certs='/etc/ssl/certs/ca-bundle.crt')


### PR DESCRIPTION
```
[root@c2dcc9a1d871 ~]# /usr/libexec/apel/apel_report.py
...
  File "/usr/local/lib/python3.6/site-packages/elasticsearch/transport.py", line 638, in raise_error
    raise UnsupportedProductError(message)
elasticsearch.exceptions.UnsupportedProductError: The client noticed that the server is not Elasticsearch and we do not support this unknown product
```