### PR TITLE
s3-backup: Modify to use UBI minimal source, rather than inheriting micro

### DIFF
--- a/opensciencegrid/s3-backup/Dockerfile
+++ b/opensciencegrid/s3-backup/Dockerfile
@@ -1,8 +1,11 @@
-FROM minio/mc:latest
+FROM minio/mc:latest as mc
 
-RUN microdnf install tar xz && \
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+RUN microdnf install -y tar xz && \
     microdnf clean all
 
 COPY s3-backup.sh /usr/local/bin/
+COPY --from=mc /usr/bin/mc /usr/bin
 
 ENTRYPOINT ["/usr/local/bin/s3-backup.sh"]


### PR DESCRIPTION
UBI micro does not include dnf