### PR TITLE
Update 51-ganglia-ce-dashboards.conf to configure reset metrics

### DIFF
--- a/opensciencegrid/ospool-ganglia/51-ganglia-ce-dashboards.conf
+++ b/opensciencegrid/ospool-ganglia/51-ganglia-ce-dashboards.conf
@@ -7,7 +7,12 @@ GANGLIAD_CE.COLLECTOR_HOST = chtc-spark-ce1.svc.opensciencegrid.org:9619
 GANGLIAD_CE.GANGLIAD_LOG = $(GANGLIAD_LOG).ce
 GANGLIAD_CE.GANGLIAD_METRICS_CONFIG_DIR = $(GANGLIAD_METRICS_CONFIG_DIR)/ce_dashboards
 GANGLIAD_CE.GANGLIAD_DEBUG = D_FULLDEBUG
-#GANGLIAD_CE.GANGLIAD_REQUIREMENTS = MyType=!="Machine" || (regexp("^([ec]|atlas|gpu|gpulab|wid-|mem|spalding)[0-9]+\.chtc\.wisc\.edu$",Machine) == true)
+
+# Enable reset metrics functionality, which first appears in
+# HTCSS version 23.6.x.  This functionality is critical to keeping
+# the CE Dashboard data correct.
+GANGLIAD_CE.GANGLIAD_WANT_RESET_METRICS = true
+GANGLIAD_CE.GANGLIAD_RESET_METRICS_FILE = gangliad_ce
 
 GANGLIAD_PER_EXECUTE_NODE_METRICS = false
 GANGLIA_SEND_DATA_FOR_ALL_HOSTS = true


### PR DESCRIPTION
Enable reset metrics functionality in the condor_gangliad, which first appears in HTCSS version 23.6.x.  This functionality is critical to keeping the CE Dashboard data correct. Note the ospool-container container should ideally not be rebooted until it such time as the image will contain HTCSS 23.6.x.