### PR TITLE
OSPool: include z/d processes in the health checks

### DIFF
--- a/opensciencegrid/ospool-cm/healthy.sh
+++ b/opensciencegrid/ospool-cm/healthy.sh
@@ -16,5 +16,17 @@ if [ -r /var/log/condor/NegotiatorLog ]; then
     fi
 fi
 
+procs_z=$(ps axo pid,stat | awk '$2 ~ /^Z/ { print $1 }' | wc -l)
+if [ "$procs_z" -gt 0 ]; then
+    echo "Found $procs_z zombie processes" >&2
+    exit 4
+fi
+
+procs_d=$(ps axo pid,stat | awk '$2 ~ /^D/ { print $1 }' | wc -l)
+if [ "$procs_d" -gt 0 ]; then
+    echo "Found $procs_d deadlocked processes" >&2
+    exit 5
+fi
+
 exit 0
 

--- a/opensciencegrid/vo-frontend/healthy.sh
+++ b/opensciencegrid/vo-frontend/healthy.sh
@@ -10,5 +10,17 @@ if ! supervisorctl status >/dev/null 2>&1; then
     exit 2
 fi
 
+procs_z=$(ps axo pid,stat | awk '$2 ~ /^Z/ { print $1 }' | wc -l)
+if [ "$procs_z" -gt 0 ]; then
+    echo "Found $procs_z zombie processes" >&2
+    exit 3
+fi
+
+procs_d=$(ps axo pid,stat | awk '$2 ~ /^D/ { print $1 }' | wc -l)
+if [ "$procs_d" -gt 0 ]; then
+    echo "Found $procs_d deadlocked processes" >&2
+    exit 4
+fi
+
 exit 0
 


### PR DESCRIPTION
These are important to trigger HA failover to the secondary CM, and make sure the frontend resets in case of problems.