### PR TITLE
SOFTWARE-5448: Exit the supervisord init process if squid exits

### DIFF
--- a/opensciencegrid/frontier-squid/start-frontier-squid.sh
+++ b/opensciencegrid/frontier-squid/start-frontier-squid.sh
@@ -23,3 +23,7 @@ trap "$STARTSTOPSCRIPT stop" TERM
 export SQUID_START_ARGS="--foreground"
 $STARTSTOPSCRIPT start &
 wait
+
+# Halt the supervisord init process after squid exits
+# Per https://github.com/Supervisor/supervisor/issues/712
+kill -s SIGINT `cat /var/run/supervisord.pid`


### PR DESCRIPTION
A closed issue in supervisord recommends sending a SIGINT to supervisord at the end of a supervised process as a potential approach for exiting on the exit of the service: https://github.com/Supervisor/supervisor/issues/712 Since supervisord is the init process of this container, the whole container will exit if the waited-on squid process ends in `start-frontier-squid.sh`