### PR TITLE
use gwms provided tarball script

### DIFF
--- a/opensciencegrid/gwms-factory/etc/osg/image-init.d/16_prep_tarball_script.sh
+++ b/opensciencegrid/gwms-factory/etc/osg/image-init.d/16_prep_tarball_script.sh
@@ -5,5 +5,5 @@
 cp /etc/gwms-factory/get_tarballs.yaml.base /etc/gwms-factory/hooks.reconfig.pre/get_tarballs.yaml
 chown gfactory: /etc/gwms-factory/hooks.reconfig.pre/get_tarballs.yaml
 
-# this line is temporary until get_tarballs is merged in the upstream gwms codebase
-ln -s /opt/factools/hooks.reconfig.pre/get_tarballs.py /etc/gwms-factory/hooks.reconfig.pre/get_tarballs.py
+# enable tarball script as a pre-reconfig hook
+ln -s /usr/lib/python3.9/site-packages/glideinwms/factory/tools/get_tarballs.py /etc/gwms-factory/hooks.reconfig.pre/get_tarballs.py


### PR DESCRIPTION
We used to pull get_tarball.py script from factools. Now it is supplied by gwms, so use that one instead.