### PR TITLE
Resolved issue with push job to use the image config string to determine what repo to push to for docker and harbor per image

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -189,8 +189,8 @@ jobs:
             echo "All required environment variables are set."
           fi
           
-      - name: Push to Harbor (${{ env.OSG_SERIES }}-development)
-        if: env.OSG_SERIES != '23'
+      - name: Push to Harbor (${OSG_SERIES}-development)
+        if: ${{ env.BASE_REPO == 'development' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: development
@@ -200,9 +200,9 @@ jobs:
           registry_url: hub.opensciencegrid.org
           registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
           registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
-
-      - name: Push to Harbor (${{ env.OSG_SERIES }}-testing)
-        if: always()
+        
+      - name: Push to Harbor (${OSG_SERIES}-testing)
+        if: ${{ env.BASE_REPO == 'testing' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: testing
@@ -212,9 +212,9 @@ jobs:
           registry_url: hub.opensciencegrid.org
           registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
           registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
-
-      - name: Push to Harbor (${{ env.OSG_SERIES }}-release)
-        if: always()
+      
+      - name: Push to Harbor (${OSG_SERIES}-release)
+        if: ${{ env.BASE_REPO == 'release' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: release
@@ -224,9 +224,9 @@ jobs:
           registry_url: hub.opensciencegrid.org
           registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
           registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
-
-      - name: Push to Docker Hub (${{ env.OSG_SERIES }}-development)
-        if: always()
+      
+      - name: Push to Docker Hub (${OSG_SERIES}-development)
+        if: ${{ env.BASE_REPO == 'development' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: development
@@ -236,9 +236,9 @@ jobs:
           registry_url: docker.io
           registry_user: ${{ secrets.DOCKER_USERNAME }}
           registry_pass: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push to Docker Hub (${{ env.OSG_SERIES }}-testing)
-        if: always()
+      
+      - name: Push to Docker Hub (${OSG_SERIES}-testing)
+        if: ${{ env.BASE_REPO == 'testing' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: testing
@@ -248,9 +248,9 @@ jobs:
           registry_url: docker.io
           registry_user: ${{ secrets.DOCKER_USERNAME }}
           registry_pass: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push to Docker Hub (${{env.OSG_SERIES }}-release)
-        if: always()
+      
+      - name: Push to Docker Hub (${OSG_SERIES}-release)
+        if: ${{ env.BASE_REPO == 'release' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: release


### PR DESCRIPTION
This change to the push job will allow the push job to determine what repo (development, testing, release) to push to based on the images config string. This ensures that an individual image doesn't get pushed to multiple repos for a single GHA job for that specific image. 

An example config string for an image may be: el9-23-development-True-False
In this case the push job will push to the development repo for both docker and harbor, previously it would have pushed to all three repos development, testing, and release for both docker and harbor.

