### PR TITLE
Fix issue with push jobs skipping over Harbor dev

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -189,8 +189,8 @@ jobs:
             echo "All required environment variables are set."
           fi
           
-      - name: Push to Harbor (${{ env.OSG_SERIES }}-development)
-        if: env.OSG_SERIES != '23'
+      - name: Push to Harbor (${OSG_SERIES}-development)
+        if: ${{ env.BASE_REPO == 'development' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: development
@@ -200,9 +200,9 @@ jobs:
           registry_url: hub.opensciencegrid.org
           registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
           registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
-
-      - name: Push to Harbor (${{ env.OSG_SERIES }}-testing)
-        if: always()
+        
+      - name: Push to Harbor (${OSG_SERIES}-testing)
+        if: ${{ env.BASE_REPO == 'testing' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: testing
@@ -212,9 +212,9 @@ jobs:
           registry_url: hub.opensciencegrid.org
           registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
           registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
-
-      - name: Push to Harbor (${{ env.OSG_SERIES }}-release)
-        if: always()
+      
+      - name: Push to Harbor (${OSG_SERIES}-release)
+        if: ${{ env.BASE_REPO == 'release' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: release
@@ -224,9 +224,9 @@ jobs:
           registry_url: hub.opensciencegrid.org
           registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
           registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
-
-      - name: Push to Docker Hub (${{ env.OSG_SERIES }}-development)
-        if: always()
+      
+      - name: Push to Docker Hub (${OSG_SERIES}-development)
+        if: ${{ env.BASE_REPO == 'development' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: development
@@ -236,9 +236,9 @@ jobs:
           registry_url: docker.io
           registry_user: ${{ secrets.DOCKER_USERNAME }}
           registry_pass: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push to Docker Hub (${{ env.OSG_SERIES }}-testing)
-        if: always()
+      
+      - name: Push to Docker Hub (${OSG_SERIES}-testing)
+        if: ${{ env.BASE_REPO == 'testing' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: testing
@@ -248,9 +248,9 @@ jobs:
           registry_url: docker.io
           registry_user: ${{ secrets.DOCKER_USERNAME }}
           registry_pass: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push to Docker Hub (${{env.OSG_SERIES }}-release)
-        if: always()
+      
+      - name: Push to Docker Hub (${OSG_SERIES}-release)
+        if: ${{ env.BASE_REPO == 'release' }}
         uses: opensciencegrid/push-container-action@main
         with:
           repo: release

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -189,11 +189,10 @@ jobs:
             echo "All required environment variables are set."
           fi
           
-      - name: Push to Harbor (${OSG_SERIES}-development)
-        if: ${{ env.BASE_REPO == 'development' }}
+      - name: Push to Harbor (${OSG_SERIES}-${BASE_REPO})
         uses: opensciencegrid/push-container-action@main
         with:
-          repo: development
+          repo: ${{ env.BASE_REPO }
           osg_series: ${{ env.OSG_SERIES }}
           context: ${{ env.CONTEXT }}
           base_os: ${{ env.BASE_OS }}
@@ -201,59 +200,10 @@ jobs:
           registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
           registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
         
-      - name: Push to Harbor (${OSG_SERIES}-testing)
-        if: ${{ env.BASE_REPO == 'testing' }}
+      - name: Push to Docker Hub (${OSG_SERIES}-${BASE_REPO})
         uses: opensciencegrid/push-container-action@main
         with:
-          repo: testing
-          osg_series: ${{ env.OSG_SERIES }}
-          context: ${{ env.CONTEXT }}
-          base_os: ${{ env.BASE_OS }}
-          registry_url: hub.opensciencegrid.org
-          registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
-          registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
-      
-      - name: Push to Harbor (${OSG_SERIES}-release)
-        if: ${{ env.BASE_REPO == 'release' }}
-        uses: opensciencegrid/push-container-action@main
-        with:
-          repo: release
-          osg_series: ${{ env.OSG_SERIES }}
-          context: ${{ env.CONTEXT }}
-          base_os: ${{ env.BASE_OS }}
-          registry_url: hub.opensciencegrid.org
-          registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
-          registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
-      
-      - name: Push to Docker Hub (${OSG_SERIES}-development)
-        if: ${{ env.BASE_REPO == 'development' }}
-        uses: opensciencegrid/push-container-action@main
-        with:
-          repo: development
-          osg_series: ${{ env.OSG_SERIES }}
-          context: ${{ env.CONTEXT }}
-          base_os: ${{ env.BASE_OS }}
-          registry_url: docker.io
-          registry_user: ${{ secrets.DOCKER_USERNAME }}
-          registry_pass: ${{ secrets.DOCKER_PASSWORD }}
-      
-      - name: Push to Docker Hub (${OSG_SERIES}-testing)
-        if: ${{ env.BASE_REPO == 'testing' }}
-        uses: opensciencegrid/push-container-action@main
-        with:
-          repo: testing
-          osg_series: ${{ env.OSG_SERIES }}
-          context: ${{ env.CONTEXT }}
-          base_os: ${{ env.BASE_OS }}
-          registry_url: docker.io
-          registry_user: ${{ secrets.DOCKER_USERNAME }}
-          registry_pass: ${{ secrets.DOCKER_PASSWORD }}
-      
-      - name: Push to Docker Hub (${OSG_SERIES}-release)
-        if: ${{ env.BASE_REPO == 'release' }}
-        uses: opensciencegrid/push-container-action@main
-        with:
-          repo: release
+          repo: ${{ env.BASE_REPO }}
           osg_series: ${{ env.OSG_SERIES }}
           context: ${{ env.CONTEXT }}
           base_os: ${{ env.BASE_OS }}


### PR DESCRIPTION
In https://github.com/opensciencegrid/images/pull/204, we changed the push job matrix from one push job per image name to one push per image name, base OS, base OSG repo combination. This was necessary to support per-image configurations but now the per-repo push job steps are unnecessary as the repo is encoded at the job level now.