### PR TITLE
Reduce number of builds for images without OSG Software

### DIFF
--- a/opensciencegrid/access-amie/build-config.json
+++ b/opensciencegrid/access-amie/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/opensciencegrid/central-syslog/build-config.json
+++ b/opensciencegrid/central-syslog/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/opensciencegrid/contact-sync/build-config.json
+++ b/opensciencegrid/contact-sync/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/opensciencegrid/default-build-config.json
+++ b/opensciencegrid/default-build-config.json
@@ -3,5 +3,5 @@
     "repo_build": false,
     "base_os": ["el9"],
     "osg_series": ["23"],
-    "base_repo": ["development", "testing", "release"] 
+    "base_repo": ["development", "testing", "release"]
   }

--- a/opensciencegrid/gracc-apel/build-config.json
+++ b/opensciencegrid/gracc-apel/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/opensciencegrid/koji-builder/build-config.json
+++ b/opensciencegrid/koji-builder/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/opensciencegrid/logrotate/build-config.json
+++ b/opensciencegrid/logrotate/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/opensciencegrid/mailchimp-sync/build-config.json
+++ b/opensciencegrid/mailchimp-sync/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/opensciencegrid/osgconnect-report/build-config.json
+++ b/opensciencegrid/osgconnect-report/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/opensciencegrid/ospool-static-registry/build-config.json
+++ b/opensciencegrid/ospool-static-registry/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["development", "testing", "release"]
+  }

--- a/opensciencegrid/s3-backup/build-config.json
+++ b/opensciencegrid/s3-backup/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/opensciencegrid/sssd/build-config.json
+++ b/opensciencegrid/sssd/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/opensciencegrid/stompclt/build-config.json
+++ b/opensciencegrid/stompclt/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/opensciencegrid/svn-to-git/build-config.json
+++ b/opensciencegrid/svn-to-git/build-config.json
@@ -1,0 +1,7 @@
+{
+    "standard_build": true,
+    "repo_build": false,
+    "base_os": ["el9"],
+    "osg_series": ["23"],
+    "base_repo": ["release"]
+  }

--- a/scripts/build-job-matrix.py
+++ b/scripts/build-job-matrix.py
@@ -5,6 +5,7 @@ from itertools import product
 
 DEFAULT_CONFIG_PATH = 'opensciencegrid/default-build-config.json'
 
+
 def load_config(config_path, default_config=None):
     """Load JSON configuration from the given path."""
     try:
@@ -19,8 +20,9 @@ def load_config(config_path, default_config=None):
         else:
             raise
 
+
 def main(image_dirs):
-    print("Image directories:", image_dirs)  
+    print("Image directories:", image_dirs)
 
     default_config = load_config(DEFAULT_CONFIG_PATH)
 
@@ -55,9 +57,10 @@ def main(image_dirs):
             configuration_string = f"{base_os}-{osg_series}-{base_repo}-{config['standard_build']}-{config['repo_build']}"
             include_list.append({"name": image_name, "config": configuration_string})
 
-    sys.stdout.flush()  
+    sys.stdout.flush()
     json_output = json.dumps({"include": include_list}, indent=4)
     print(json_output)
+
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:


### PR DESCRIPTION
There's no sense in having OSG development / testing images for images that don't actually pull in any OSG RPMs.

Note that many of these images actually do get some OSG Software from the software-base image but in those cases, they don't pull any subsequent packages, i.e. the image functionality does not depend on the OSG Software RPM replease pipeline. Many of these images mostly want to use the runtime `/etc/osg/image-init.d` feature from the base image.