### PR TITLE
OSPool CM: relax the D proc check

### DIFF
--- a/opensciencegrid/ospool-cm/healthy.sh
+++ b/opensciencegrid/ospool-cm/healthy.sh
@@ -18,13 +18,13 @@ fi
 
 procs_z=$(ps axo pid,stat | awk '$2 ~ /^Z/ { print $1 }' | wc -l)
 if [ "$procs_z" -gt 0 ]; then
-    echo "Found $procs_z zombie processes" >&2
+    echo "Found $procs_z zombie (Z) processes" >&2
     exit 4
 fi
 
 procs_d=$(ps axo pid,stat | awk '$2 ~ /^D/ { print $1 }' | wc -l)
-if [ "$procs_d" -gt 0 ]; then
-    echo "Found $procs_d deadlocked processes" >&2
+if [ "$procs_d" -gt 3 ]; then
+    echo "Found $procs_d uninterruptible (D) processes" >&2
     exit 5
 fi
 


### PR DESCRIPTION
A few uninterruptible can be expected. We don't want to trigger the health probe failure until there are a bunch of them (>3).