### PR TITLE
SOFTWARE-6022: OSG-24

### DIFF
--- a/opensciencegrid/access-amie/build-config.json
+++ b/opensciencegrid/access-amie/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/access-amie/build-config.json
+++ b/opensciencegrid/access-amie/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/access-amie/build-config.json
+++ b/opensciencegrid/access-amie/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/central-syslog/build-config.json
+++ b/opensciencegrid/central-syslog/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/central-syslog/build-config.json
+++ b/opensciencegrid/central-syslog/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/central-syslog/build-config.json
+++ b/opensciencegrid/central-syslog/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/contact-sync/build-config.json
+++ b/opensciencegrid/contact-sync/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/contact-sync/build-config.json
+++ b/opensciencegrid/contact-sync/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/contact-sync/build-config.json
+++ b/opensciencegrid/contact-sync/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/default-build-config.json
+++ b/opensciencegrid/default-build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["development", "testing", "release"]
   }

--- a/opensciencegrid/default-build-config.json
+++ b/opensciencegrid/default-build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["development", "testing", "release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/default-build-config.json
+++ b/opensciencegrid/default-build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["development", "testing", "release"]
   }

--- a/opensciencegrid/gracc-apel/build-config.json
+++ b/opensciencegrid/gracc-apel/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/gracc-apel/build-config.json
+++ b/opensciencegrid/gracc-apel/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/gracc-apel/build-config.json
+++ b/opensciencegrid/gracc-apel/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/koji-builder/build-config.json
+++ b/opensciencegrid/koji-builder/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/koji-builder/build-config.json
+++ b/opensciencegrid/koji-builder/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/koji-builder/build-config.json
+++ b/opensciencegrid/koji-builder/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/logrotate/build-config.json
+++ b/opensciencegrid/logrotate/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/logrotate/build-config.json
+++ b/opensciencegrid/logrotate/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/logrotate/build-config.json
+++ b/opensciencegrid/logrotate/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/mailchimp-sync/build-config.json
+++ b/opensciencegrid/mailchimp-sync/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/mailchimp-sync/build-config.json
+++ b/opensciencegrid/mailchimp-sync/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/mailchimp-sync/build-config.json
+++ b/opensciencegrid/mailchimp-sync/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/osgconnect-report/build-config.json
+++ b/opensciencegrid/osgconnect-report/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/osgconnect-report/build-config.json
+++ b/opensciencegrid/osgconnect-report/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/osgconnect-report/build-config.json
+++ b/opensciencegrid/osgconnect-report/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/ospool-static-registry/build-config.json
+++ b/opensciencegrid/ospool-static-registry/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/ospool-static-registry/build-config.json
+++ b/opensciencegrid/ospool-static-registry/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/ospool-static-registry/build-config.json
+++ b/opensciencegrid/ospool-static-registry/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/s3-backup/build-config.json
+++ b/opensciencegrid/s3-backup/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/s3-backup/build-config.json
+++ b/opensciencegrid/s3-backup/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/s3-backup/build-config.json
+++ b/opensciencegrid/s3-backup/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/sssd/build-config.json
+++ b/opensciencegrid/sssd/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/sssd/build-config.json
+++ b/opensciencegrid/sssd/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/sssd/build-config.json
+++ b/opensciencegrid/sssd/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/stompclt/build-config.json
+++ b/opensciencegrid/stompclt/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/stompclt/build-config.json
+++ b/opensciencegrid/stompclt/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/stompclt/build-config.json
+++ b/opensciencegrid/stompclt/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/svn-to-git/build-config.json
+++ b/opensciencegrid/svn-to-git/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24"],
-    "base_repo": ["development"]
+    "osg_series": ["23"],
+    "base_repo": ["release"]
   }

--- a/opensciencegrid/svn-to-git/build-config.json
+++ b/opensciencegrid/svn-to-git/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
-    "base_repo": ["release"]
+    "osg_series": ["24"],
+    "base_repo": ["development"]
   }

--- a/opensciencegrid/svn-to-git/build-config.json
+++ b/opensciencegrid/svn-to-git/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23"],
+    "osg_series": ["23", "24"],
     "base_repo": ["release"]
   }


### PR DESCRIPTION
- Add OSG 24 to build matrices

The GHA for the first (reverted) commit in this PR tests building every image into 24-development, all builds succeed: https://github.com/mwestphall/images/actions/runs/11521078633/job/32073908568