### PR TITLE
gracc-apel: Update python-daemon to address high memory usage

### DIFF
--- a/opensciencegrid/gracc-apel/Dockerfile
+++ b/opensciencegrid/gracc-apel/Dockerfile
@@ -28,6 +28,13 @@ RUN    pip3 install --no-cache-dir \
          opensearch-py \
          requests
 
+# EPEL for EL9 ships python3-daemon-2.3.2-1.el9.noarch
+# It uses excessive memory when nofile ulimit is high, fixed in >= v3.0.0
+# https://pagure.io/python-daemon/issue/72
+# TODO: Revert after EPEL package is updated
+RUN    pip3 install --no-cache-dir --upgrade \
+         python-daemon
+
 RUN    mkdir /etc/grid-security/apel \
     && mkdir -p /var/spool/apel/outgoing/12345678
 


### PR DESCRIPTION
k8s containers have a high nofiles ulimit (1073741816) and this causes python-daemon to use a large amount of RAM, leading to OOM.

This is fixed in v3 of python-daemon. https://pagure.io/python-daemon/issue/72