### PR TITLE
frontier-squid: Adjust startup script for path change

### DIFF
--- a/opensciencegrid/frontier-squid/start-frontier-squid.sh
+++ b/opensciencegrid/frontier-squid/start-frontier-squid.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 # Wrapper script for starting & stopping frontier squid from supervisord
 
-STARTSTOPSCRIPT=/etc/init.d/frontier-squid
+STARTSTOPSCRIPT=/usr/libexec/squid/frontier-squid
+if [ ! -x "$STARTSTOPSCRIPT" ]; then
+    # Try the < frontier-squid-5.9-3.2 path
+    # FIXME: Remove when 5.9-2.1 is deprecated
+    STARTSTOPSCRIPT=/etc/init.d/frontier-squid
+fi
+
 if [ "$(id -u)" != 0 ]; then
     STARTSTOPSCRIPT=/usr/sbin/fn-local-squid.sh
     if [ -f /etc/sysconfig/frontier-squid ]; then


### PR DESCRIPTION
The /etc/init.d/frontier-squid script was moved to /usr/libexec/squid/frontier-squid in frontier-squid-5.9-3.2+. Try the new path first, and fall back to the old path.