### PR TITLE
CE dashboard updates to monitor all hosted CEs

### DIFF
--- a/opensciencegrid/ospool-ganglia/51-ganglia-ce-dashboards.conf
+++ b/opensciencegrid/ospool-ganglia/51-ganglia-ce-dashboards.conf
@@ -14,6 +14,21 @@ GANGLIAD_CE.GANGLIAD_DEBUG = D_FULLDEBUG
 GANGLIAD_CE.GANGLIAD_WANT_RESET_METRICS = true
 GANGLIAD_CE.GANGLIAD_RESET_METRICS_FILE = gangliad_ce
 
+# All the hosted CEs what we monitor use SSL for authentication, so don't
+# waste time (and log failures at FULLDEBUG) with other methods
+GANGLIAD_CE.SEC_CLIENT_AUTHENTICATION_METHODS=SSL
+
+# We definitely wanna use projections when querying dozens of CEs !
+# May as well use projections for all gangliad processes to save RAM.
+GANGLIAD_WANT_PROJECTION = True
+# Don't bother to wait a long time for a response.
+GANGLIAD_CE.QUERY_TIMEOUT = 5
+
+# Tell the gangliad which Schedd Ads to look at in the top-level collector
+# to automatically come up with the list of collectors to monitor
+GANGLIAD_CE.MONITOR_COLLECTOR = collector.opensciencegrid.org:9619
+GANGLIAD_CE.MONITOR_COLLECTOR_CONSTRAINT = regexp("hosted-ce.*(\.grid\.uchicago\.edu|\.opensciencegrid\.org)|.*\.svc\.opensciencegrid\.org", Machine)
+
 # The default min metric lifetime is only 1 day, meaning if a project
 # does not use a CE for more than a day, all historic data about this project
 # will be purged. So reset min metric lifetime to 548 days (47,347,200 seconds)

--- a/opensciencegrid/ospool-ganglia/Dockerfile
+++ b/opensciencegrid/ospool-ganglia/Dockerfile
@@ -27,6 +27,7 @@ RUN dnf -y distro-sync && \
       rrdtool \
       vim \
       wget \
+      lrzsz \
     && \
     dnf -y clean all && \
     mkdir -p /run/php-fpm

--- a/opensciencegrid/ospool-ganglia/ganglia.d/ce_dashboards/51_ce_dashboard_metrics
+++ b/opensciencegrid/ospool-ganglia/ganglia.d/ce_dashboards/51_ce_dashboard_metrics
@@ -16,6 +16,24 @@
 ]
 [
   Aggregate = "SUM";
+  Name   = "BcusInUse";
+  Desc   = "Number of 1core-4GB-4GB Basic Computing Units provisioned";
+  Value  = floor(min({totalslotcpus,totalslotmemory/1024/4,totalslotdisk/1024/1024/4}))-floor(min({cpus,Memory/1024/4,Disk/1024/1024/4}));
+  Units  = "Basic Computing Units";
+  Requirements = PartitionableSlot=?=True;
+  TargetType = "Machine";
+]
+[
+  Aggregate = "SUM";
+  Name   = "BcusNotInUse";
+  Desc   = "Number of 1core-4GB-4GB Basic Computing Units not provisioned";
+  Value  = floor(min({cpus,Memory/1024/4,Disk/1024/1024/4}));
+  Units  = "Basic Computing Units";
+  Requirements = PartitionableSlot=?=True;
+  TargetType = "Machine";
+]
+[
+  Aggregate = "SUM";
   Name   = "CpusInUse";
   Desc   = "Number of CPU cores provisioned for running jobs";
   Value  = Cpus;

--- a/opensciencegrid/ospool-ganglia/ganglia.d/ce_dashboards/51_ce_dashboard_metrics
+++ b/opensciencegrid/ospool-ganglia/ganglia.d/ce_dashboards/51_ce_dashboard_metrics
@@ -70,6 +70,33 @@
 ]
 [
   Aggregate = "SUM";
+  Name   = "DiskInUse";
+  Desc   = "Amount of disk provisioned";
+  Value  = Disk/1024.0/1024;
+  Units  = "gigabytes";
+  Requirements = ( State == "Claimed" || State=="Preempting" ) && Activity != "Idle" && Activity != "Suspended";
+  TargetType = "Machine";
+]
+[
+  Aggregate = "SUM";
+  Name   = strcat("Disk_Project ",replaceall("^[^.]*\\.|\\..+@.+$", AccountingGroup,"")?:"Unknown");
+  Desc   = "Amount of disk provisioned per project";
+  Value  = Disk/1024.0/1024;
+  Units  = "gigabytes";
+  Requirements = ( State == "Claimed" || State=="Preempting" );
+  TargetType = "Machine";
+]
+[
+  Aggregate = "SUM";
+  Name   = "DiskNotInUse";
+  Desc   = "Amount of disk not provisioned";
+  Value  = Disk/1024.0/1024;
+  Units  = "gigabytes";
+  Requirements = ( ( State == "Claimed" || State == "Preempting" ) && Activity != "Idle" && Activity != "Suspended" ) == false;
+  TargetType =  "Machine";
+]
+[
+  Aggregate = "SUM";
   Name   = "GpusInUse";
   Desc   = "Number of GPU devices provisioned";
   Value  = Gpus?:0;

--- a/opensciencegrid/ospool-ganglia/ganglia.d/ce_dashboards/51_ce_dashboard_metrics
+++ b/opensciencegrid/ospool-ganglia/ganglia.d/ce_dashboards/51_ce_dashboard_metrics
@@ -43,7 +43,7 @@
 ]
 [
   Aggregate = "SUM";
-  Name   = strcat("Cpus_Project ",replaceall("^[^.]*\\.|\\..+@.+$", AccountingGroup,"")?:"Unknown");
+  Name   = strcat("Cpus_Project ",ifThenElse(ProjectName=!=UNDEFINED,ProjectName,replaceall("^[^.]*\\.|\\..+@.+$", AccountingGroup,"")?:"Unknown"));
   Desc   = "Number of CPU cores provisioned per project";
   Value  = Cpus;
   Units  = "cores";
@@ -70,7 +70,7 @@
 ]
 [
   Aggregate = "SUM";
-  Name   = strcat("Memory_Project ",replaceall("^[^.]*\\.|\\..+@.+$", AccountingGroup,"")?:"Unknown");
+  Name   = strcat("Memory_Project ",ifThenElse(ProjectName=!=UNDEFINED,ProjectName,replaceall("^[^.]*\\.|\\..+@.+$", AccountingGroup,"")?:"Unknown"));
   Desc   = "Amount of memory provisioned per project";
   Value  = Memory;
   Units  = "megabytes";
@@ -97,7 +97,7 @@
 ]
 [
   Aggregate = "SUM";
-  Name   = strcat("Disk_Project ",replaceall("^[^.]*\\.|\\..+@.+$", AccountingGroup,"")?:"Unknown");
+  Name   = strcat("Disk_Project ",ifThenElse(ProjectName=!=UNDEFINED,ProjectName,replaceall("^[^.]*\\.|\\..+@.+$", AccountingGroup,"")?:"Unknown"));
   Desc   = "Amount of disk provisioned per project";
   Value  = Disk/1024.0/1024;
   Units  = "gigabytes";
@@ -124,7 +124,7 @@
 ]
 [
   Aggregate = "SUM";
-  Name   = strcat("Gpus_Project ",replaceall("^[^.]*\\.|\\..+@.+$", AccountingGroup,"")?:"Unknown");
+  Name   = strcat("Gpus_Project ",ifThenElse(ProjectName=!=UNDEFINED,ProjectName,replaceall("^[^.]*\\.|\\..+@.+$", AccountingGroup,"")?:"Unknown"));
   Desc   = "Number of GPUs provisioned per project";
   Value  = Gpus;
   Units  = "devices";


### PR DESCRIPTION
Changes to ospool-ganglia to:

1. Monitor all hosted CE Dashboards.  **NOTE:  This changes requires that HTCSS can successfully query the CM at collector.opensciencegrid.org:9619, which has not been true since mid-december 2024 when the InCommon SSL host cert on this CM was updated.  Maybe /etc/grid-security CA certs need to be updated?**
2. Add Basic Computing Unit (BCU) metrics
3. Add EP Disk Usage metrics
4. Add Zmodem to the ospool-ganglia image to make ToddT happy :)