### PR TITLE
Configure to use grid-security to find CA certs.

### DIFF
--- a/opensciencegrid/ospool-ganglia/51-ganglia-ce-dashboards.conf
+++ b/opensciencegrid/ospool-ganglia/51-ganglia-ce-dashboards.conf
@@ -17,6 +17,11 @@ GANGLIAD_CE.GANGLIAD_RESET_METRICS_FILE = gangliad_ce
 # All the hosted CEs what we monitor use SSL for authentication, so don't
 # waste time (and log failures at FULLDEBUG) with other methods
 GANGLIAD_CE.SEC_CLIENT_AUTHENTICATION_METHODS=SSL
+# Practially all central managers setup by PATh use InCommon certs,
+# so tell HTCSS where to find these CA certs.  Don't bother to
+# scope this just to the GANGLIAD_CE, just make it global so
+# tools like condor_status will work as well.
+AUTH_SSL_CLIENT_CADIR = /etc/grid-security/certificates
 
 # We definitely wanna use projections when querying dozens of CEs !
 # May as well use projections for all gangliad processes to save RAM.


### PR DESCRIPTION
This is required to talk to collector.opensciencegrid.org, and prolly other central managers, that require authentication and use an InCommon SSL cert.