### PR TITLE
Stop building some internal images for OSG 23

### DIFF
--- a/opensciencegrid/gracc-apel/build-config.json
+++ b/opensciencegrid/gracc-apel/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23", "24"],
+    "osg_series": ["24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/koji-builder/build-config.json
+++ b/opensciencegrid/koji-builder/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23", "24"],
+    "osg_series": ["24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/logrotate/build-config.json
+++ b/opensciencegrid/logrotate/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23", "24"],
+    "osg_series": ["24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/ospool-static-registry/build-config.json
+++ b/opensciencegrid/ospool-static-registry/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23", "24"],
+    "osg_series": ["24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/s3-backup/build-config.json
+++ b/opensciencegrid/s3-backup/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23", "24"],
+    "osg_series": ["24"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/svn-to-git/build-config.json
+++ b/opensciencegrid/svn-to-git/build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["23", "24"],
+    "osg_series": ["24"],
     "base_repo": ["release"]
   }


### PR DESCRIPTION
This won't affect running services:

- gracc-apel: using "latest"
- koji-builder: using 24-release already (albeit with a timestamped version)
- logrotate: using 24-release (or a timestamped version of 23-release or 24-release)
- svn-to-git: using either a fixed version or 23-testing (which doesn't get automatically built)
- s3-backup: using an image from 2021
- ospool-static-registry: using 23-development (which doesn't get automatically built)