### PR TITLE
koji-builder: updates

### DIFF
--- a/opensciencegrid/koji-builder/Dockerfile
+++ b/opensciencegrid/koji-builder/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_OSG_SERIES=23
+ARG BASE_OSG_SERIES=24
 ARG BASE_YUM_REPO=release
 ARG BASE_OS=el9
 
@@ -8,14 +8,10 @@ FROM opensciencegrid/software-base:$BASE_OSG_SERIES-$BASE_OS-$BASE_YUM_REPO
 
 ARG BASE_OSG_SERIES
 
-LABEL maintainer OSG Software <help@opensciencegrid.org>
+LABEL maintainer OSG Software <help@osg-htc.org>
 
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
- if [[ $BASE_OSG_SERIES = 3.6 ]]; then \
-   yum install -y --enablerepo=devops-itb 'koji-builder >= 1.21.1'; \
- else \
-   yum install -y --enablerepo=osg-internal-development 'koji-builder'; \
- fi
+   yum install -y --enablerepo=osg-internal-development 'koji-builder'
 
 COPY kojid-supervisord.conf  /etc/supervisord.d/kojid.conf
 COPY koji_ca_cert.crt  /etc/pki/tls/certs/koji_ca_cert.crt

--- a/opensciencegrid/koji-builder/build
+++ b/opensciencegrid/koji-builder/build
@@ -1,5 +1,5 @@
 #!/bin/bash
-: "${BASE_OSG_SERIES:=3.6}"
+: "${BASE_OSG_SERIES:=24}"
 : "${BASE_YUM_REPO:=release}"
 docker build --build-arg BASE_OSG_SERIES="$BASE_OSG_SERIES" --build-arg BASE_YUM_REPO="$BASE_YUM_REPO" \
     -t "opensciencegrid/koji-builder:$BASE_YUM_REPO" .

--- a/opensciencegrid/koji-builder/create-config.sh
+++ b/opensciencegrid/koji-builder/create-config.sh
@@ -39,6 +39,7 @@ allowed_scms=
     github.com:/unlhcc/hcc-packaging.git:no:fetch-sources,.
     github.com:/opensciencegrid/Software-Redhat.git:no:fetch-sources,.
     github.com:/CHTC/packaging.git:no:fetch-sources,.
+    github.com:/osg-htc/software-packaging.git:no:fetch-sources,.
 
 cert = $KOJID_CERTKEY
 serverca = /etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
- Set BASE_OSG_SERIES to 24
- Drop support for BASE_OSG_SERIES==3.6
- Add support for building from github.com/osg-htc/software-packaging