### PR TITLE
Explicitly set the HOME dir for the frontend

### DIFF
--- a/opensciencegrid/vo-frontend/supervisor.d/10-gwms-fe.conf
+++ b/opensciencegrid/vo-frontend/supervisor.d/10-gwms-fe.conf
@@ -4,6 +4,7 @@ command=/usr/sbin/httpd -DFOREGROUND
 [program:frontend]
 command=bash -c "sleep 30s; python3 /usr/sbin/glideinFrontend /var/lib/gwms-frontend/vofrontend"
 user=frontend
+environment=HOME=/var/lib/gwms-frontend
 autorestart=true
 startsecs=60
 


### PR DESCRIPTION
By default, supervisord doesn't change HOME or other environment vars, and so even if you run a service as a different user, HOME will be /root unless set otherwise. This wasn't a problem until gWMS made a change to make the frontend look at $HOME to set its token dir:

https://github.com/glideinWMS/glideinwms/commit/1d7fa0af05d4d30c303c68c5d8bdc5d296176787