### PR TITLE
Bump the default frequency of the logrotate cron job

### DIFF
--- a/opensciencegrid/logrotate/Dockerfile
+++ b/opensciencegrid/logrotate/Dockerfile
@@ -2,8 +2,8 @@ FROM almalinux:9
 
 LABEL maintainer OSG Software <help@osg-htc.org>
 
-# Run Logrotate once per hour
-ENV CRON_EXPR="0 * * * *"
+# Run Logrotate every five minutes
+ENV CRON_EXPR="*/5 * * * *"
 # Extra options to logrotate (if any)
 ENV LOGROTATE_OPTIONS=
 # File path(s) for LogRotate config files


### PR DESCRIPTION
Since log rotation is based on date or size, this doesn't cause the logs to be rotated more frequently, it just causes logrotate to check for the rotation condition more frequently, allowing it to catch sudden growths in size. logrotate itself has locking so this should be safe.