### PR TITLE
OSPool: relax uninterruptible (D) process check

### DIFF
--- a/opensciencegrid/ospool-cm/healthy.sh
+++ b/opensciencegrid/ospool-cm/healthy.sh
@@ -23,7 +23,7 @@ if [ "$procs_z" -gt 3 ]; then
 fi
 
 procs_d=$(ps axo pid,stat | awk '$2 ~ /^D/ { print $1 }' | wc -l)
-if [ "$procs_d" -gt 3 ]; then
+if [ "$procs_d" -gt 15 ]; then
     echo "Found $procs_d uninterruptible (D) processes" >&2
     exit 5
 fi


### PR DESCRIPTION
This health check triggers excessively and does not indicate a problem with the pod.