### PR TITLE
Add kuantifier build via submodule

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -30,50 +30,52 @@ jobs:
 
       - id: image-list
         run: |
-          ORG_DIR=opensciencegrid
-          # Get the list of files changed based on the type of event
-          # kicking off the GHA:
-          # 1. For the main branch, diff the previous state of main vs
-          #    the current commit
-          # 2. For other branches (i.e., on someone's fork), diff main
-          #    vs the current commit
-          # 3. For PRs, diff the base ref vs the current commit
-          # 4. For everything else (e.g., dispatches), build all images
-          if [[ $GITHUB_EVENT_NAME == 'pull_request' ]] ||
-             [[ $GITHUB_EVENT_NAME == 'push' ]]; then
-               if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
-                   BASE=$(git merge-base origin/$GITHUB_BASE_REF HEAD)
-               elif [[ $GITHUB_REF == 'refs/heads/main' ]]; then
-                   BASE=${{github.event.before}}
-               else
-                   BASE=origin/main
-               fi
-               # List image root dirs where files have changed and the
-               # root dir exists. Example value:
-               # "opensciencegrid/vo-frontend opensciencegrid/ospool-cm"
-               images=$(git diff --name-only \
-                                 "$BASE" \
-                                 "$GITHUB_SHA" |
-                        egrep "^$ORG_DIR/" |
-                        cut -d/ -f -2 |
-                        sort |
-                        uniq |
-                        xargs -I {} find . -type d \
-                                           -wholename ./{} \
-                                           -printf "%P\n")
-          else
-               # List all image root dirs. Example value:
-               # "opensciencegrid/vo-frontend opensciencegrid/ospool-cm"
-               images=$(find $ORG_DIR -mindepth 1 \
-                                      -maxdepth 1 \
-                                      -type d \
-                                      -printf "$ORG_DIR/%P\n")
-          fi
+          images=""
+          for ORG_DIR in opensciencegrid iris-hep; do
+            # Get the list of files changed based on the type of event
+            # kicking off the GHA:
+            # 1. For the main branch, diff the previous state of main vs
+            #    the current commit
+            # 2. For other branches (i.e., on someone's fork), diff main
+            #    vs the current commit
+            # 3. For PRs, diff the base ref vs the current commit
+            # 4. For everything else (e.g., dispatches), build all images
+            if [[ $GITHUB_EVENT_NAME == 'pull_request' ]] ||
+              [[ $GITHUB_EVENT_NAME == 'push' ]]; then
+                if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
+                    BASE=$(git merge-base origin/$GITHUB_BASE_REF HEAD)
+                elif [[ $GITHUB_REF == 'refs/heads/main' ]]; then
+                    BASE=${{github.event.before}}
+                else
+                    BASE=origin/main
+                fi
+                # List image root dirs where files have changed and the
+                # root dir exists. Example value:
+                # "opensciencegrid/vo-frontend opensciencegrid/ospool-cm"
+                images="$images "$(git diff --name-only \
+                                  "$BASE" \
+                                  "$GITHUB_SHA" |
+                          egrep "^$ORG_DIR/" |
+                          cut -d/ -f -2 |
+                          sort |
+                          uniq |
+                          xargs -I {} find . -type d \
+                                            -wholename ./{} \
+                                            -printf "%P\n")
+            else
+                # List all image root dirs. Example value:
+                # "opensciencegrid/vo-frontend opensciencegrid/ospool-cm"
+                images="$images "$(find $ORG_DIR -mindepth 1 \
+                                        -maxdepth 1 \
+                                        -type d \
+                                        -printf "$ORG_DIR/%P\n")
+            fi
+          done
 
-            image_json=$(echo -n "${images:-dummy}" | jq -Rcs '.|split("\n") | map(select(. != ""))')
-            echo "$image_json" > image_list.json
-            echo "images=$(echo $images | tr '\n' ' ')" >> $GITHUB_OUTPUT
-            echo "image_list=$image_json" >> $GITHUB_OUTPUT
+          image_json=$(echo -n "${images:-dummy}" | jq -Rcs '.|split("\n") | map(select(. != ""))')
+          echo "$image_json" > image_list.json
+          echo "images=$(echo $images | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          echo "image_list=$image_json" >> $GITHUB_OUTPUT
 
       - name: Display image list
         run: cat image_list.json
@@ -111,6 +113,8 @@ jobs:
         include: ${{ fromJson(needs.build-image-list.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
         # Example of a matrix configuration string:
         # {el9-23-development-True-False}
       - name: Print raw matrix configuration
@@ -124,11 +128,17 @@ jobs:
           BASE_OS=$(echo $CONFIG | awk -F'-' '{print $1}')
           OSG_SERIES=$(echo $CONFIG | awk -F'-' '{print $2}')
           BASE_REPO=$(echo $CONFIG | awk -F'-' '{print $3}')
-          CONTEXT="opensciencegrid/${{ matrix.name }}"
+          CONTEXT="${{ matrix.context }}"
+          ORGANIZATION=$(echo $CONTEXT | cut -d'/' -f1)
           echo "BASE_OS=${BASE_OS}" >> $GITHUB_ENV
           echo "OSG_SERIES=${OSG_SERIES}" >> $GITHUB_ENV
           echo "BASE_REPO=${BASE_REPO}" >> $GITHUB_ENV
           echo "CONTEXT=${CONTEXT}" >> $GITHUB_ENV
+          if [ -n "${{ matrix.tag_override }}" ] ; then
+            echo "IMAGE_NAME=${ORGANIZATION}/${{ matrix.name }}:${{ matrix.tag_override }}" >> $GITHUB_ENV
+          else
+            echo "IMAGE_NAME=${ORGANIZATION}/${{ matrix.name }}:${OSG_SERIES}-${BASE_OS}-${BASE_REPO}" >> $GITHUB_ENV
+          fi
 
       - name: Validate Environment Variables
         run: |
@@ -148,6 +158,7 @@ jobs:
           osg_repo: ${{ env.BASE_REPO }}
           context: ${{ env.CONTEXT }}
           base_os: ${{ env.BASE_OS }}
+          output_image: ${{ env.IMAGE_NAME }}
 
   push:
     runs-on: ubuntu-latest
@@ -176,11 +187,17 @@ jobs:
           BASE_OS=$(echo $CONFIG | awk -F'-' '{print $1}')
           OSG_SERIES=$(echo $CONFIG | awk -F'-' '{print $2}')
           BASE_REPO=$(echo $CONFIG | awk -F'-' '{print $3}')
-          CONTEXT="opensciencegrid/${{ matrix.name }}"
+          CONTEXT="${{ matrix.context }}"
+          ORGANIZATION=$(echo $CONTEXT | cut -d'/' -f1)
           echo "BASE_OS=${BASE_OS}" >> $GITHUB_ENV
           echo "OSG_SERIES=${OSG_SERIES}" >> $GITHUB_ENV
           echo "BASE_REPO=${BASE_REPO}" >> $GITHUB_ENV
           echo "CONTEXT=${CONTEXT}" >> $GITHUB_ENV
+          if [ -n "${{ matrix.tag_override }}" ] ; then
+            echo "IMAGE_NAME=${ORGANIZATION}/${{ matrix.name }}:${{ matrix.tag_override }}" >> $GITHUB_ENV
+          else
+            echo "IMAGE_NAME=${ORGANIZATION}/${{ matrix.name }}:${OSG_SERIES}-${BASE_OS}-${BASE_REPO}" >> $GITHUB_ENV
+          fi
 
       - name: Validate Environment Variables
         run: |
@@ -199,6 +216,7 @@ jobs:
           osg_series: ${{ env.OSG_SERIES }}
           context: ${{ env.CONTEXT }}
           base_os: ${{ env.BASE_OS }}
+          image_name: ${{ env.IMAGE_NAME }}
           registry_url: hub.opensciencegrid.org
           registry_user: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
           registry_pass: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
@@ -210,6 +228,7 @@ jobs:
           osg_series: ${{ env.OSG_SERIES }}
           context: ${{ env.CONTEXT }}
           base_os: ${{ env.BASE_OS }}
+          image_name: ${{ env.IMAGE_NAME }}
           registry_url: docker.io
           registry_user: ${{ secrets.DOCKER_USERNAME }}
           registry_pass: ${{ secrets.DOCKER_PASSWORD }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "opensciencegrid/kuantifier/kuantifier"]
+	path = iris-hep/kuantifier/kuantifier
+	url = git@github.com:rptaylor/kuantifier.git

--- a/iris-hep/kuantifier/Dockerfile
+++ b/iris-hep/kuantifier/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12
+ARG UID=10000
+ARG GID=10000
+
+WORKDIR /src
+COPY kuantifier/python/requirements.txt .
+RUN pip install -r requirements.txt
+COPY kuantifier/python/*.py ./
+
+USER $UID:$GID
+CMD python3 KAPEL.py

--- a/iris-hep/kuantifier/build-config.json
+++ b/iris-hep/kuantifier/build-config.json
@@ -1,0 +1,9 @@
+{
+  "standard_build": true,
+  "repo_build": false,
+  "base_os": ["el9"],
+  "osg_series": ["24"],
+  "base_repo": ["release"],
+  "context": "kuantifier",
+  "tag": "1.0.2"
+}

--- a/scripts/build-job-matrix.py
+++ b/scripts/build-job-matrix.py
@@ -41,6 +41,9 @@ def main(image_dirs):
         osg_series_list = config['osg_series']
         base_repo_list = config['base_repo']
 
+        build_context = config.get('context', '')
+        tag_override = config.get('tag', '')
+
         combinations = product(
             base_os_list,
             osg_series_list,
@@ -56,7 +59,12 @@ def main(image_dirs):
         # 1. Simplicity: Using a single string to represent configurations is straightforward and easy to understand.
         # 2. Integration: A single string is easily passed to external tools and systems that manage builds.
             configuration_string = f"{base_os}-{osg_series}-{base_repo}-{config['standard_build']}-{config['repo_build']}"
-            include_list.append({"name": image_name, "config": configuration_string})
+            include_list.append({
+                "name": image_name, 
+                "config": configuration_string, 
+                "tag_override": tag_override,
+                "context": os.path.join(image_dir, build_context)
+            })
 
     sys.stdout.flush()
     json_output = json.dumps({"include": include_list}, indent=4)


### PR DESCRIPTION
- Add kuantifier as a build target via git submodules
- Add a `context` field to build-config.json to allow docker building in the pulled submodule rather than `opensciencegrid/<image name>`
- Add `tag` field to build-config.json to allow building to a specific semver tag rather than `24-elX-release`
- Bash scriptery to variably build into `iris-hep` or `opensciencegrid` organization based on image directory