### PR TITLE
Allow no arguments to the --before flag 

### DIFF
--- a/scripts/build-job-matrix.py
+++ b/scripts/build-job-matrix.py
@@ -84,8 +84,6 @@ def main(image_dirs):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        sys.exit(f"Usage: {sys.argv[0]} <image_dirs>")
-
+    # If run with zero arguments, output an empty list
     image_dirs = sys.argv[1:]
     main(image_dirs)

--- a/scripts/detect-changed-images.py
+++ b/scripts/detect-changed-images.py
@@ -52,6 +52,8 @@ def get_updated_images():
             elif GITHUB_REF == 'refs/head/main':
                 base = args.before
             current_commit = repo.commit(GITHUB_SHA)
+
+            print(base, current_commit, GITHUB_EVENT_NAME, GITHUB_REF)
             diff_paths = {f"{_image_from_path(d.a_path)}" for d in current_commit.diff(base) if d.a_path.startswith(org_dir)}
             # Only interested in the top two path entries
             updated_images += diff_paths

--- a/scripts/detect-changed-images.py
+++ b/scripts/detect-changed-images.py
@@ -53,7 +53,6 @@ def get_updated_images():
                 base = args.before
             current_commit = repo.commit(GITHUB_SHA)
 
-            print(base, current_commit, GITHUB_EVENT_NAME, GITHUB_REF)
             diff_paths = {f"{_image_from_path(d.a_path)}" for d in current_commit.diff(base) if d.a_path.startswith(org_dir)}
             # Only interested in the top two path entries
             updated_images += diff_paths

--- a/scripts/detect-changed-images.py
+++ b/scripts/detect-changed-images.py
@@ -12,7 +12,7 @@ import json
 ORG_DIRS = ['opensciencegrid', 'iris-hep']
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--before', help='SHA of the previous commit to compare against')
+parser.add_argument('--before', nargs='?', help='SHA of the previous commit to compare against')
 args = parser.parse_args()
 
 


### PR DESCRIPTION
In the case that the GHA is being run without a previous commit, eg. in the case of a non-pull-request dispatch, the GHA will try to run `detect-changes-images.py --before` with no arg to before. This change allows the script to be run when the argument is supplied in that way.

eg: https://github.com/mwestphall/images/actions/runs/16604754099/job/46973554960

Also, output an empty build matrix rather than error-ing when no changed images are detected (such as in the case of this pull request)