### PR TITLE
Use a modified supervisord startup script that removes the cleanup program from the supervisord config so `supervisorctl status` doesn't exit nonzero

### DIFF
--- a/opensciencegrid/frontier-squid/Dockerfile
+++ b/opensciencegrid/frontier-squid/Dockerfile
@@ -41,6 +41,12 @@ RUN rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch && \
     yum install -y filebeat && \
     rm -rf /var/cache/yum/*
 
+# Use a modified supervisord startup script that removes the cleanup
+# program from the supervisord config so `supervisorctl status`
+# doesn't exit nonzero.
+# TODO: Remove when https://github.com/opensciencegrid/docker-software-base/pull/105 is merged.
+COPY supervisord_startup.sh /usr/local/sbin/supervisord_startup.sh
+
 COPY start-frontier-squid.sh /usr/sbin/
 COPY squid-customize.sh /etc/squid/customize.sh
 COPY customize.d/* /etc/squid/customize.d/

--- a/opensciencegrid/frontier-squid/supervisord_startup.sh
+++ b/opensciencegrid/frontier-squid/supervisord_startup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Allow the derived images to run any additional runtime customizations
+shopt -s nullglob
+for x in /etc/osg/image-init.d/*.sh; do source "$x"; done
+shopt -u nullglob
+
+chmod go-w /etc/cron.*/* 2>/dev/null || :
+
+if [[ -z $(shopt -s nullglob && echo /etc/osg/image-cleanup.d/*.sh) ]]; then
+    rm -f /etc/supervisord.d/00-cleanup.conf
+fi
+
+
+# Now we can actually start the supervisor
+# Use whatever user id this container as run as
+exec /usr/bin/supervisord -c /etc/supervisord.conf -u $(id -u)
+


### PR DESCRIPTION
(Revert after https://github.com/opensciencegrid/docker-software-base/pull/105 is merged)