### PR TITLE
Create 13-misc-fixes.sh

### DIFF
--- a/opensciencegrid/xrootd-standalone/image-config.d/13-misc-fixes.sh
+++ b/opensciencegrid/xrootd-standalone/image-config.d/13-misc-fixes.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-chwon xrootd: /etc/xrootd/macaroon-secret
+chown xrootd: /etc/xrootd/macaroon-secret
 mkdir /var/run/xrootd
 chown xrootd: /var/run/xrootd

--- a/opensciencegrid/xrootd-standalone/image-config.d/13-misc-fixes.sh
+++ b/opensciencegrid/xrootd-standalone/image-config.d/13-misc-fixes.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+chwon xrootd: /etc/xrootd/macaroon-secret
+mkdir /var/run/xrootd
+chown xrootd: /var/run/xrootd


### PR DESCRIPTION
Creates dir /var/run/xrootd which is expected by xrootd Set permissions to macaroon-secret, assumes the user has provided one and put in tin /etc/xrootd/macaroon-secret