### PR TITLE
By default, only build opensciencegrid images for 25-release

### DIFF
--- a/opensciencegrid/default-build-config.json
+++ b/opensciencegrid/default-build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["25"],
+    "osg_series": ["24", "25"],
     "base_repo": ["release"]
   }

--- a/opensciencegrid/default-build-config.json
+++ b/opensciencegrid/default-build-config.json
@@ -2,6 +2,6 @@
     "standard_build": true,
     "repo_build": false,
     "base_os": ["el9"],
-    "osg_series": ["24", "25"],
-    "base_repo": ["development", "testing", "release"]
+    "osg_series": ["25"],
+    "base_repo": ["release"]
   }


### PR DESCRIPTION
People can always override it by making their own build-config.json files.