### PR TITLE
Bump opensciencegrid/build-container-action to v0.8.1

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Build Image
         continue-on-error: ${{ matrix.yum_repo == 'development' }}
-        uses: opensciencegrid/build-container-action@v0.6.0
+        uses: opensciencegrid/build-container-action@v0.8.1
         with:
           osg_series: ${{ env.OSG_SERIES }}
           osg_repo: ${{ env.BASE_REPO }}


### PR DESCRIPTION
This contains version updates for the components; maybe one of them will fix the 'Duplicate header: "Authorization"' build issue when doing a `git fetch`.