### PR TITLE
squid supervisor echo stdout/stderr from child process

### DIFF
--- a/opensciencegrid/frontier-squid/supervisor-frontier-squid.conf
+++ b/opensciencegrid/frontier-squid/supervisor-frontier-squid.conf
@@ -1,3 +1,7 @@
 [program:frontier-squid]
 command=/usr/sbin/start-frontier-squid.sh
 stopwaitsecs=90
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
[Supervisord captures stdout/stderr from its child processes by default.](https://supervisord.org/logging.html#child-process-logs) This is bad for a container entrypoint for obvious reasons. In my case, I broke my `squid.conf`, and when I tried to start my container, it would immediately exit with no error message.

before:

```
Aug 20 13:46:43 atlas-squid frontier-squid[43410]: System crypto policies are: DEFAULT
Aug 20 13:46:43 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:43,662 INFO Included extra file "/etc/supervisord.d/40-frontier-squid.conf" during parsing
Aug 20 13:46:43 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:43,662 INFO Set uid to user 0 succeeded
Aug 20 13:46:43 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:43,665 INFO RPC interface 'supervisor' initialized
Aug 20 13:46:43 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:43,665 CRIT Server 'unix_http_server' running without any HTTP authentication checking
Aug 20 13:46:43 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:43,665 INFO supervisord started with pid 1
Aug 20 13:46:44 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:44,667 INFO spawned: 'crond' with pid 23
Aug 20 13:46:44 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:44,669 INFO spawned: 'frontier-squid' with pid 24
Aug 20 13:46:45 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:45,203 INFO exited: frontier-squid (exit status 0; not expected)
Aug 20 13:46:45 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:45,203 WARN received SIGINT indicating exit request
Aug 20 13:46:45 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:45,203 INFO waiting for crond to die
Aug 20 13:46:46 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:46,204 INFO success: crond entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Aug 20 13:46:46 atlas-squid frontier-squid[43410]: 2026-08-20 13:46:46,210 INFO stopped: crond (exit status 0)
Aug 20 13:46:46 atlas-squid podman[43535]: 2026-08-20 13:46:46.252307034 +0000 UTC m=+0.019840077 container died f368aa1819c5b2894c02f7ec33e7b5f3284f0e2bf2ea9aa054b03ef2d72fa057 (image=docker.io/opensciencegrid/frontier-squid:24-release-20260809-0817, name=frontier-squid, PODMAN_SYSTEMD_UNIT=frontier-squid.service, maintainer=OSG Software <help@opensciencegrid.org>)
Aug 20 13:46:46 atlas-squid podman[43535]: 2026-08-20 13:46:46.289272056 +0000 UTC m=+0.056805088 container remove f368aa1819c5b2894c02f7ec33e7b5f3284f0e2bf2ea9aa054b03ef2d72fa057 (image=docker.io/opensciencegrid/frontier-squid:24-release-20260809-0817, name=frontier-squid, maintainer=OSG Software <help@opensciencegrid.org>, PODMAN_SYSTEMD_UNIT=frontier-squid.service)
```

After I configured supervisor to echo stdout/stderr, I can now see my error message:

```
Aug 20 13:58:50 atlas-squid frontier-squid[44031]: System crypto policies are: DEFAULT
Aug 20 13:58:50 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:50,410 INFO Included extra file "/etc/supervisord.d/40-frontier-squid.conf" during parsing
Aug 20 13:58:50 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:50,410 INFO Included extra file "/etc/supervisord.d/supervisor-frontier-squid.conf" during parsing
Aug 20 13:58:50 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:50,410 INFO Set uid to user 0 succeeded
Aug 20 13:58:50 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:50,413 INFO RPC interface 'supervisor' initialized
Aug 20 13:58:50 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:50,413 CRIT Server 'unix_http_server' running without any HTTP authentication checking
Aug 20 13:58:50 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:50,413 INFO supervisord started with pid 1
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:51,416 INFO spawned: 'crond' with pid 23
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:51,418 INFO spawned: 'frontier-squid' with pid 24
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: Generating /etc/squid/squid.conf
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: Configured cache_mem of 128 MB exceeds shared memory in /dev/shm.
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: cache_mem set to 50 MB to fit into available space.
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: Checking if Frontier Squid running...
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: 2026/08/20 13:58:51| Processing Configuration File: /etc/squid/squid.conf (depth 0)
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: 2026/08/20 13:58:51| ERROR: ACL not found: MAJOR_CVMFS
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: 2026/08/20 13:58:51| Not currently OK to rewrite swap log.
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: 2026/08/20 13:58:51| storeDirWriteCleanLogs: Operation aborted.
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: 2026/08/20 13:58:51| FATAL: Bungled /etc/squid/squid.conf line 1656: http_access allow MAJOR_CVMFS
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: 2026/08/20 13:58:51| Squid Cache (Version frontier-squid-6.14-1.3.osg24up.el8): Terminated abnormally.
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: CPU Usage: 0.004 seconds = 0.003 user + 0.001 sys
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: Maximum Resident Size: 39936 KB
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: Page faults with physical i/o: 0
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: ERROR parsing /etc/squid/squid.conf
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:51,957 INFO exited: frontier-squid (exit status 0; not expected)
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:51,957 WARN received SIGINT indicating exit request
Aug 20 13:58:51 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:51,957 INFO waiting for crond to die
Aug 20 13:58:52 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:52,959 INFO success: crond entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Aug 20 13:58:52 atlas-squid frontier-squid[44031]: 2026-08-20 13:58:52,963 INFO stopped: crond (exit status 0)
Aug 20 13:58:53 atlas-squid podman[44154]: 2026-08-20 13:58:53.005857676 +0000 UTC m=+0.020172429 container died 1e7eed28a6bbb4c9c0993b409a6baf79c3a1416f9ab8093c56ca1a8750a094ec (image=docker.io/opensciencegrid/frontier-squid:24-release-20260809-0817, name=frontier-squid, maintainer=OSG Software <help@opensciencegrid.org>, PODMAN_SYSTEMD_UNIT=frontier-squid.service)
Aug 20 13:58:53 atlas-squid podman[44154]: 2026-08-20 13:58:53.046679273 +0000 UTC m=+0.060994008 container remove 1e7eed28a6bbb4c9c0993b409a6baf79c3a1416f9ab8093c56ca1a8750a094ec (image=docker.io/opensciencegrid/frontier-squid:24-release-20260809-0817, name=frontier-squid, PODMAN_SYSTEMD_UNIT=frontier-squid.service, maintainer=OSG Software <help@opensciencegrid.org>)
Aug 20 13:58:53 atlas-squid systemd[939]: frontier-squid.service: Consumed 1.090s CPU time.
```